### PR TITLE
before_filter is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Et voilà:
 
 ```ruby
 class VerySecretThingsController < ApplicationController
-  before_filter :require_user!
+  before_action :require_user!
   
   def index
     @things = current_user.very_secret_things


### PR DESCRIPTION
As of Rails 5.1(?) using `before_filter` will result in

> undefined method `before_filter' for ... Did you mean? before_action`

and a deprecation warning in earlier versions of Rails.