### PR TITLE
Add as: :authenticatable to sessions association

### DIFF
--- a/lib/passwordless/model_helpers.rb
+++ b/lib/passwordless/model_helpers.rb
@@ -8,7 +8,7 @@ module Passwordless
     #   field name (e.g. `:email`)
     # @param field [string] email submitted by user.
     def passwordless_with(field)
-      has_many :passwordless_sessions, class_name: 'Passwordless::Session'
+      has_many :passwordless_sessions, class_name: 'Passwordless::Session', as: :authenticatable
       define_singleton_method(:passwordless_email_field) { field }
     end
   end

--- a/test/fixtures/passwordless/sessions.yml
+++ b/test/fixtures/passwordless/sessions.yml
@@ -13,3 +13,11 @@ two:
   user_agent: MyText
   remote_addr: MyString
   token: MyString
+
+john:
+  timeout_at: 2017-11-04 23:17:35
+  expires_at: 2017-11-04 23:17:35
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.62 Safari/537.36"
+  remote_addr: 127.0.0.1
+  token: 3veDCdFw4VedgZtZZkCJ7um7rsc2bFNCZGB51Iih024
+  authenticatable: john (User)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,2 +1,5 @@
 alice:
   email: alice@example.com
+
+john:
+  email: john@example.com

--- a/test/models/authenticatable_test.rb
+++ b/test/models/authenticatable_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class AuthenticatableTest < ActiveSupport::TestCase
+  test "#passwordless_sessions" do
+    user = users(:john)
+    assert_equal [passwordless_sessions(:john)], user.passwordless_sessions
+  end
+end


### PR DESCRIPTION
This PR adds the missing `as: :authenticatable` to the model helper when creating the association.

Without it, the `user.passwordless_sessions` returns an error as the constructed SQL looks up by `user_id` instead of `authenticatable_id`.

Closes #23