### PR TITLE
Enable logging in with STI subclass

### DIFF
--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -72,11 +72,11 @@ module Passwordless
     private
 
     def session_key(authenticatable_class)
-      :"passwordless_prev_location--#{authenticatable_class}"
+      :"passwordless_prev_location--#{authenticatable_class.base_class}"
     end
 
     def cookie_name(authenticatable_class)
-      :"#{authenticatable_class.to_s.underscore}_id"
+      :"#{authenticatable_class.base_class.to_s.underscore}_id"
     end
   end
 end


### PR DESCRIPTION
Say you have a `User` model using STI, with an `Admin` subclass.
Previously, if an `Admin` attempted to log in, their id would be saved in the `admin_id` key.
Then, when calling `authenticate_by_cookie(User)` (since we don't know the subclass of the user until the record is loaded), no user would be loaded, since it would look for the `user_id` key.

This changes the session keys to use the `base_class`, which is the root class of the STI hierarchy. That way, for the above scenario, the ID is both saved and loaded using the `user_id` key, so logging in works.

This shouldn't affect non-STI models, since `base_class` would just return the class itself