### PR TITLE
Session: validate authenticatable presence explicitly

### DIFF
--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -8,6 +8,7 @@ module Passwordless
       polymorphic: true, inverse_of: :passwordless_sessions
 
     validates \
+      :authenticatable,
       :timeout_at,
       :expires_at,
       :user_agent,


### PR DESCRIPTION
It is required when `config.load_defaults 5.2` is absent from `application.rb`. Otherwise, when entering email for non-existent user this code from `session_controller.rb` works incorrectly:

```
def create
  session = build_passwordless_session(find_authenticatable)

  if session.save
    Mailer.magic_link(session).deliver_now
  end

  render
end
```

`save` actually returns `true` and `Mailer.magic_link(nil)` is called.