### PR TITLE
Add callback to customize method of notifying magic link to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Add authentication to your Rails app without all the icky-ness of passwords.
      * [Token and Session Expiry](#token-and-session-expiry)
      * [Redirecting back after sign-in](#redirecting-back-after-sign-in)
      * [URLs and links](#urls-and-links)
-     * [E-mail security](#e-mail-security)
      * [Customize the way to send magic link](#customize_the_way_to_send_magic_link)
+     * [E-mail security](#e-mail-security)
 * [License](#license)
 
 ## Installation
@@ -233,13 +233,6 @@ passwordless_for :users, at: '/', as: :auth
 
 Also be sure to [specify ActionMailer's `default_url_options.host`](http://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views).
 
-### E-mail security
-
-There's no reason that this approach should be less secure than the usual username/password combo. In fact this is most often a more secure option, as users don't get to choose the weak passwords they still use. In a way this is just the same as having each user go through "Forgot password" on every login.
-
-But be aware that when everyone authenticates via emails you send, the way you send those mails becomes a weak spot. Email services usually provide a log of all the mails you send so if your app's account is compromised, every user in the system is as well. (This is the same for "Forgot password".) [Reddit was compromised](https://thenextweb.com/hardfork/2018/01/05/reddit-bitcoin-cash-hack/) using this method.
-
-Ideally you should set up your email provider to not log these mails. And be sure to turn on 2-factor auth if your provider supports it.
 
 ### Customize the way to send magic link
 
@@ -249,12 +242,24 @@ config/initializers/passwordless.rb
 
 ```
 Passwordless.after_session_save = lambda do |session|
-  # do something with session model
-  # e.g) session.authenticatable.send_sms
+  # Default behavior is
+  # Mailer.magic_link(session).deliver_now
+
+  # You can change behavior to do something with session model. For example,
+  # session.authenticatable.send_sms
 end
 ```
 
 You can access user model through authenticatable.
+
+
+### E-mail security
+
+There's no reason that this approach should be less secure than the usual username/password combo. In fact this is most often a more secure option, as users don't get to choose the weak passwords they still use. In a way this is just the same as having each user go through "Forgot password" on every login.
+
+But be aware that when everyone authenticates via emails you send, the way you send those mails becomes a weak spot. Email services usually provide a log of all the mails you send so if your app's account is compromised, every user in the system is as well. (This is the same for "Forgot password".) [Reddit was compromised](https://thenextweb.com/hardfork/2018/01/05/reddit-bitcoin-cash-hack/) using this method.
+
+Ideally you should set up your email provider to not log these mails. And be sure to turn on 2-factor auth if your provider supports it.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Add authentication to your Rails app without all the icky-ness of passwords.
      * [Redirecting back after sign-in](#redirecting-back-after-sign-in)
      * [URLs and links](#urls-and-links)
      * [E-mail security](#e-mail-security)
+     * [Customize the way to send magic link](#customize_the_way_to_send_magic_link)
 * [License](#license)
 
 ## Installation
@@ -239,6 +240,21 @@ There's no reason that this approach should be less secure than the usual userna
 But be aware that when everyone authenticates via emails you send, the way you send those mails becomes a weak spot. Email services usually provide a log of all the mails you send so if your app's account is compromised, every user in the system is as well. (This is the same for "Forgot password".) [Reddit was compromised](https://thenextweb.com/hardfork/2018/01/05/reddit-bitcoin-cash-hack/) using this method.
 
 Ideally you should set up your email provider to not log these mails. And be sure to turn on 2-factor auth if your provider supports it.
+
+### Customize the way to send magic link
+
+By default, magic link will send by email. You can customize this method. For example, you can send magic link via SMS.
+
+config/initializers/passwordless.rb
+
+```
+Passwordless.after_session_save = lambda do |session|
+  # do something with session model
+  # e.g) session.authenticatable.send_sms
+end
+```
+
+You can access user model through authenticatable.
 
 # License
 

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -26,7 +26,7 @@ module Passwordless
       session = build_passwordless_session(find_authenticatable)
 
       if session.save
-        Mailer.magic_link(session).deliver_now
+        Passwordless.after_session_save.call(session)
       end
 
       render

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -12,4 +12,6 @@ module Passwordless
 
   mattr_accessor(:expires_at) { lambda { 1.year.from_now } }
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
+
+  mattr_accessor(:after_session_save) { lambda { |session| Mailer.magic_link(session).deliver_now } }
 end

--- a/passwordless.gemspec
+++ b/passwordless.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 5.1.4"
   s.add_dependency "bcrypt", "~> 3.1.11"
 
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.3.6"
   s.add_development_dependency "yard"
   s.add_development_dependency "rubocop"
 end

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -26,6 +26,23 @@ module Passwordless
       assert_equal 1, ActionMailer::Base.deliveries.size
     end
 
+    test 'magic link will send by custom method' do
+      old_proc = Passwordless.after_session_save
+      called = false
+      Passwordless.after_session_save = lambda { |_| called = true }
+
+      User.create email: 'a@a'
+
+      post '/users/sign_in',
+        params: { passwordless: { email: 'A@a' } },
+        headers: { 'User-Agent': 'an actual monkey' }
+      assert_equal 200, status
+
+      assert_equal true, called
+
+      Passwordless.after_session_save = old_proc
+    end
+
     test 'requesting a magic link as an unknown user' do
       get '/users/sign_in'
       assert_equal 200, status


### PR DESCRIPTION
I wanted to change the way to notify users of magic link. For example, SMS may notify magic link.

e.g 

```
Passwordless.after_session_save = lambda { |session| session.authenticatable.send_sms_or_something_method } 
```