### PR TITLE
Use timeout instead of expired at SessionsController#show

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -45,7 +45,7 @@ module Passwordless
       BCrypt::Password.create(params[:token])
 
       session = find_session
-      raise ExpiredSessionError if session.expired?
+      raise ExpiredSessionError if session.timed_out?
 
       sign_in session.authenticatable
 

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -26,6 +26,10 @@ module Passwordless
       expires_at <= Time.current
     end
 
+    def timed_out?
+      timeout_at <= Time.current
+    end
+
     private
 
     def set_defaults

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -158,10 +158,10 @@ module Passwordless
       assert cookies[:user_id].blank?
     end
 
-    test 'trying to sign in with an expired session' do
+    test 'trying to sign in with an timed out session' do
       user = User.create email: 'a@a'
       session = create_session_for user
-      session.update(expires_at: Time.current - 1.day)
+      session.update(timeout_at: Time.current - 1.day)
 
       get "/users/sign_in/#{session.token}"
       follow_redirect!

--- a/test/models/passwordless/session_test.rb
+++ b/test/models/passwordless/session_test.rb
@@ -27,6 +27,12 @@ module Passwordless
       assert_equal expired_session.expired?, true
     end
 
+    test 'timed_out?' do
+      timed_out_session = create_session timeout_at: 1.hour.ago
+
+      assert_equal timed_out_session.timed_out?, true
+    end
+
     test 'it has defaults' do
       session = Session.new
       session.validate

--- a/test/models/passwordless/session_test.rb
+++ b/test/models/passwordless/session_test.rb
@@ -21,6 +21,12 @@ module Passwordless
       assert_equal [valid], Session.valid.all
     end
 
+    test 'expired?' do
+      expired_session = create_session expires_at: 1.hour.ago
+
+      assert_equal expired_session.expired?, true
+    end
+
     test 'it has defaults' do
       session = Session.new
       session.validate


### PR DESCRIPTION
Fixes #38 

I didn't get the last part.

> the `expires_at` should maybe used in the `authenticate_by_cookie` method instead

If you can drop a line explaining it more I am happy to help.