### PR TITLE
get sign_in - Redirects users to root page if already signed in

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -9,6 +9,8 @@ module Passwordless
     class SessionTimedOutError < StandardError; end
 
     include ControllerHelpers
+    
+    before_action :already_signed_in, only: [:new, :create]
 
     # get '/sign_in'
     #   Assigns an email_field and new Session to be used by new view.
@@ -106,6 +108,12 @@ module Passwordless
         authenticatable_type: authenticatable_classname,
         token: params[:token]
       )
+    end
+    
+    def already_signed_in
+      if authenticate_by_cookie(User)
+        redirect_to main_app.root_path, flash: { notice: 'Already signed in!' }
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
When the user is signed in, still users will be able to go to `/users/sign_in` and create a new session.
Since `/users/sign_in` is controlled by `passwordless` gem this is essential.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)