### PR TITLE
Add functionality to mark tokens as claimed to prevent re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Add authentication to your Rails app without all the icky-ness of passwords.
 * [Usage](#usage)
      * [Getting the current user, restricting access, the usual](#getting-the-current-user-restricting-access-the-usual)
      * [Providing your own templates](#providing-your-own-templates)
+     * [Claming tokens](#claiming-tokens)
      * [Overrides](#overrides)
      * [Registering new users](#registering-new-users)
      * [Generating tokens](#generating-tokens)
@@ -236,6 +237,35 @@ end
 
 You can access user model through authenticatable.
 
+### Claiming tokens
+
+Opt-in for marking tokens as `claimed` so that they can't be used again.
+
+config/initializers/passwordless.rb
+
+```ruby
+# Default is `false`
+Passwordless.claim_token_after_sign_in = true
+```
+
+#### Upgrading an existing Rails app
+
+For small, low traffic apps, you can probably get away with a single migration (not recommended though!), however it best practice to stagger the migrations to minimise locks to the table/database. For a “high availability migration”, follow this [example gist](https://gist.github.com/JoeSouthan/78d3746e8d728d8ab47e67202b59c891).
+
+All in one migration (will lock database during migration, be cautious!):
+
+```bash
+bin/rails generate migration add_claimed_to_passwordless_sessions
+```
+
+```ruby
+class AddClaimedToPasswordlessSessions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :passwordless_sessions, :claimed, :boolean, null: false, default: false
+  end
+end
+
+```
 
 ### Overrides
 

--- a/README.md
+++ b/README.md
@@ -269,8 +269,6 @@ end
 ```
 </details>
 
-Be aware that this will lock your database while migrating. For a higher availability approach, see [this example gist](https://gist.github.com/JoeSouthan/78d3746e8d728d8ab47e67202b59c891).
-
 ### Overrides
 
 By default `passwordless` uses the `passwordless_with` column to _case insensitively_ fetch the resource.

--- a/README.md
+++ b/README.md
@@ -239,33 +239,37 @@ You can access user model through authenticatable.
 
 ### Claiming tokens
 
-Opt-in for marking tokens as `claimed` so that they can't be used again.
+Opt-in for marking tokens as `claimed` so they can only be used once.
 
 config/initializers/passwordless.rb
 
 ```ruby
 # Default is `false`
-Passwordless.claim_token_after_sign_in = true
+Passwordless.restrict_token_reuse = true
 ```
 
 #### Upgrading an existing Rails app
 
-For small, low traffic apps, you can probably get away with a single migration (not recommended though!), however it best practice to stagger the migrations to minimise locks to the table/database. For a “high availability migration”, follow this [example gist](https://gist.github.com/JoeSouthan/78d3746e8d728d8ab47e67202b59c891).
+The simplest way to update your sessions table is with a single migration:
 
-All in one migration (will lock database during migration, be cautious!):
+<details>
+<summary>Example migration</summary>
 
 ```bash
-bin/rails generate migration add_claimed_to_passwordless_sessions
+bin/rails generate migration add_claimed_at_to_passwordless_sessions
 ```
 
 ```ruby
-class AddClaimedToPasswordlessSessions < ActiveRecord::Migration[5.2]
+class AddClaimedAtToPasswordlessSessions < ActiveRecord::Migration[5.2]
   def change
-    add_column :passwordless_sessions, :claimed, :boolean, null: false, default: false
+    add_column :passwordless_sessions, :claimed_at, :datetime
   end
 end
 
 ```
+</details>
+
+Be aware that this will lock your database while migrating. For a higher availability approach, see [this example gist](https://gist.github.com/JoeSouthan/78d3746e8d728d8ab47e67202b59c891).
 
 ### Overrides
 

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -30,6 +30,10 @@ module Passwordless
       timeout_at <= Time.current
     end
 
+    def claim!
+      update!(claimed: true)
+    end
+
     private
 
     def set_defaults

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -4,6 +4,8 @@ module Passwordless
   # The session responsible for holding the connection between the record
   # trying to log in and the unique tokens.
   class Session < ApplicationRecord
+    class TokenAlreadyClaimedError < StandardError; end
+
     belongs_to :authenticatable,
       polymorphic: true, inverse_of: :passwordless_sessions
 
@@ -31,7 +33,12 @@ module Passwordless
     end
 
     def claim!
-      update!(claimed: true)
+      raise TokenAlreadyClaimedError if claimed?
+      touch(:claimed_at)
+    end
+
+    def claimed?
+      !!claimed_at
     end
 
     private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       create:
         session_expired: 'Your session has expired, please sign in again.'
         email_sent_if_record_found: "If we found you in the system, we've sent you an email."
+        token_claimed: "This link has already been used, try requesting the link again"
       new:
         submit: 'Send magic link'
     mailer:

--- a/db/migrate/20171104221735_create_passwordless_sessions.rb
+++ b/db/migrate/20171104221735_create_passwordless_sessions.rb
@@ -13,6 +13,7 @@ class CreatePasswordlessSessions < ActiveRecord::Migration[5.1]
       t.text :user_agent, null: false
       t.string :remote_addr, null: false
       t.string :token, null: false
+      t.boolean :claimed, null: false, default: false
 
       t.timestamps
     end

--- a/db/migrate/20171104221735_create_passwordless_sessions.rb
+++ b/db/migrate/20171104221735_create_passwordless_sessions.rb
@@ -10,10 +10,10 @@ class CreatePasswordlessSessions < ActiveRecord::Migration[5.1]
       )
       t.datetime :timeout_at, null: false
       t.datetime :expires_at, null: false
+      t.datetime :claimed_at
       t.text :user_agent, null: false
       t.string :remote_addr, null: false
       t.string :token, null: false
-      t.boolean :claimed, null: false, default: false
 
       t.timestamps
     end

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -7,6 +7,7 @@ require "passwordless/url_safe_base_64_generator"
 module Passwordless
   mattr_accessor(:default_from_address) { "CHANGE_ME@example.com" }
   mattr_accessor(:token_generator) { UrlSafeBase64Generator.new }
+  mattr_accessor(:claim_token_after_sign_in) { false }
   mattr_accessor(:redirect_back_after_sign_in) { true }
   mattr_accessor(:mounted_as) { :configured_when_mounting_passwordless }
 

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -7,7 +7,7 @@ require "passwordless/url_safe_base_64_generator"
 module Passwordless
   mattr_accessor(:default_from_address) { "CHANGE_ME@example.com" }
   mattr_accessor(:token_generator) { UrlSafeBase64Generator.new }
-  mattr_accessor(:claim_token_after_sign_in) { false }
+  mattr_accessor(:restrict_token_reuse) { false }
   mattr_accessor(:redirect_back_after_sign_in) { true }
   mattr_accessor(:mounted_as) { :configured_when_mounting_passwordless }
 

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -173,8 +173,8 @@ module Passwordless
     end
 
     test "trying to use a claimed token" do
-      default = Passwordless.claim_token_after_sign_in
-      Passwordless.claim_token_after_sign_in = true
+      default = Passwordless.restrict_token_reuse
+      Passwordless.restrict_token_reuse = true
       user = User.create email: "a@a"
       session = create_session_for user
 
@@ -194,7 +194,7 @@ module Passwordless
       assert_equal 200, status
       assert_equal "/", path
 
-      Passwordless.claim_token_after_sign_in = default
+      Passwordless.restrict_token_reuse = default
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2017_11_04_225303) do
     t.text "user_agent", null: false
     t.string "remote_addr", null: false
     t.string "token", null: false
+    t.boolean "claimed", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,10 +16,10 @@ ActiveRecord::Schema.define(version: 2017_11_04_225303) do
     t.integer "authenticatable_id"
     t.datetime "timeout_at", null: false
     t.datetime "expires_at", null: false
+    t.datetime "claimed_at"
     t.text "user_agent", null: false
     t.string "remote_addr", null: false
     t.string "token", null: false
-    t.boolean "claimed", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"

--- a/test/models/passwordless/session_test.rb
+++ b/test/models/passwordless/session_test.rb
@@ -33,6 +33,12 @@ module Passwordless
       assert_equal timed_out_session.timed_out?, true
     end
 
+    test "claimed?" do
+      claimed_session = create_session claimed_at: 1.hour.ago
+
+      assert_equal claimed_session.claimed?, true
+    end
+
     test "it has defaults" do
       session = Session.new
       session.validate
@@ -84,6 +90,21 @@ module Passwordless
 
       assert_equal custom_timeout_at.to_s, session.timeout_at.to_s
       Passwordless.timeout_at = old_timeout_at
+    end
+
+    test "claim! - with unclaimed session" do
+      unclaimed_session = create_session
+      unclaimed_session.claim!
+
+      refute_nil unclaimed_session.claimed_at
+    end
+
+    test "claim! - with claimed session" do
+      claimed_session = create_session claimed_at: 1.hour.ago
+
+      assert_raises(Passwordless::Session::TokenAlreadyClaimedError) do
+        claimed_session.claim!
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

To help improve the security and one time nature of the links generated by passwordless, I’ve put together a configuration option to expire tokens after a login attempt.

Let me know what you think.