### PR TITLE
Save session.id in session

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    @current_user ||= authenticate_by_cookie(User)
+    @current_user ||= authenticate_by_session(User)
   end
 
   def require_user!

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -41,10 +41,10 @@ module Passwordless
 
       session = passwordless_session
 
-      sign_in session
-
       redirect_enabled = Passwordless.redirect_back_after_sign_in
       destination = reset_passwordless_redirect_location!(User)
+
+      sign_in session
 
       if redirect_enabled && destination
         redirect_to destination

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -39,13 +39,9 @@ module Passwordless
       # Make it "slow" on purpose to make brute-force attacks more of a hassle
       BCrypt::Password.create(params[:token])
 
-      session = find_session
+      session = passwordless_session
 
-      session.claim! if Passwordless.restrict_token_reuse
-
-      raise Passwordless::Errors::SessionTimedOutError if session.timed_out?
-
-      sign_in session.authenticatable
+      sign_in session
 
       redirect_enabled = Passwordless.redirect_back_after_sign_in
       destination = reset_passwordless_redirect_location!(User)
@@ -101,8 +97,8 @@ module Passwordless
       end
     end
 
-    def find_session
-      Session.find_by!(
+    def passwordless_session
+      @passwordless_session ||= Session.find_by!(
         authenticatable_type: authenticatable_classname,
         token: params[:token]
       )

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -5,9 +5,6 @@ require "bcrypt"
 module Passwordless
   # Controller for managing Passwordless sessions
   class SessionsController < ApplicationController
-    # Raise this exception when a session is expired.
-    class SessionTimedOutError < StandardError; end
-
     include ControllerHelpers
 
     # get '/sign_in'
@@ -46,7 +43,7 @@ module Passwordless
 
       session.claim! if Passwordless.restrict_token_reuse
 
-      raise SessionTimedOutError if session.timed_out?
+      raise Passwordless::Errors::SessionTimedOutError if session.timed_out?
 
       sign_in session.authenticatable
 
@@ -58,10 +55,10 @@ module Passwordless
       else
         redirect_to main_app.root_path
       end
-    rescue Session::TokenAlreadyClaimedError
+    rescue Errors::TokenAlreadyClaimedError
       flash[:error] = I18n.t(".passwordless.sessions.create.token_claimed")
       redirect_to main_app.root_path
-    rescue SessionTimedOutError
+    rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
       redirect_to main_app.root_path
     end

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -4,8 +4,6 @@ module Passwordless
   # The session responsible for holding the connection between the record
   # trying to log in and the unique tokens.
   class Session < ApplicationRecord
-    class TokenAlreadyClaimedError < StandardError; end
-
     belongs_to :authenticatable,
       polymorphic: true, inverse_of: :passwordless_sessions
 
@@ -33,7 +31,7 @@ module Passwordless
     end
 
     def claim!
-      raise TokenAlreadyClaimedError if claimed?
+      raise Passwordless::Errors::TokenAlreadyClaimedError if claimed?
       touch(:claimed_at)
     end
 

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -39,6 +39,10 @@ module Passwordless
       !!claimed_at
     end
 
+    def valid_session?
+      !timed_out? && !expired?
+    end
+
     private
 
     def set_defaults

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "passwordless/errors"
 require "passwordless/engine"
 require "passwordless/url_safe_base_64_generator"
@@ -16,4 +17,6 @@ module Passwordless
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
 
   mattr_accessor(:after_session_save) { lambda { |session| Mailer.magic_link(session).deliver_now } }
+
+  CookieDeprecation = ActiveSupport::Deprecation.new("0.8", "passwordless")
 end

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "passwordless/errors"
 require "passwordless/engine"
 require "passwordless/url_safe_base_64_generator"
 

--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -86,7 +86,7 @@ module Passwordless
       cookies.delete(key)
       # /deprecated
 
-      session.delete session_key(authenticatable_class)
+      reset_session
       true
     end
 

--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -3,6 +3,12 @@
 module Passwordless
   # Helpers to work with Passwordless sessions from controllers
   module ControllerHelpers
+    # Returns the {Passwordless::Session} (if set) from the session.
+    # @return [Session, nil]
+    def current_passwordless_session(authenticatable_class)
+      @current_passwordless_session ||= Passwordless::Session.find_by(id: session[session_key(authenticatable_class)])
+    end
+
     # Build a new Passwordless::Session from an _authenticatable_ record.
     # Set's `user_agent` and `remote_addr` from Rails' `request`.
     # @param authenticatable [ActiveRecord::Base] Instance of an
@@ -17,6 +23,7 @@ module Passwordless
       end
     end
 
+    # @deprecated Use {ControllerHelpers#authenticate_by_session}
     # Authenticate a record using cookies. Looks for a cookie corresponding to
     # the _authenticatable_class_. If found try to find it in the database.
     # @param authenticatable_class [ActiveRecord::Base] any Model connected to
@@ -27,54 +34,98 @@ module Passwordless
     def authenticate_by_cookie(authenticatable_class)
       key = cookie_name(authenticatable_class)
       authenticatable_id = cookies.encrypted[key]
-      return unless authenticatable_id
 
-      authenticatable_class.find_by(id: authenticatable_id)
+      return authenticatable_class.find_by(id: authenticatable_id) if authenticatable_id
+
+      authenticate_by_session(authenticatable_class)
+    end
+    deprecate :authenticate_by_cookie, deprecator: CookieDeprecation
+
+    # Authenticate a record using the session. Looks for a session key corresponding to
+    # the _authenticatable_class_. If found try to find it in the database.
+    # @param authenticatable_class [ActiveRecord::Base] any Model connected to
+    #   passwordless. (e.g - _User_ or _Admin_).
+    # @return [ActiveRecord::Base|nil] an instance of Model found by id stored
+    #   in cookies.encrypted or nil if nothing is found.
+    # @see ModelHelpers#passwordless_with
+    def authenticate_by_session(authenticatable_class)
+      return unless current_passwordless_session(authenticatable_class)&.valid_session?
+      @current_authenticatable ||= current_passwordless_session(authenticatable_class).authenticatable
     end
 
-    # Signs in user by assigning their id to a permanent cookie.
-    # @param authenticatable [ActiveRecord::Base] Instance of Model to sign in
+    # Signs in user by assigning their id to the current session.
+    # @param authenticatable [ActiveRecord::Base, Passwordless::Session] Instance of Model to sign in
     #   (e.g - @user when @user = User.find(id: some_id)).
     # @return [ActiveRecord::Base] the record that is passed in.
-    def sign_in(authenticatable)
-      key = cookie_name(authenticatable.class)
-      cookies.encrypted.permanent[key] = {value: authenticatable.id}
-      authenticatable
+    def sign_in(record)
+      passwordless_session = if record.is_a?(Passwordless::Session)
+        record
+      else
+        build_passwordless_session(record).tap { |s| s.save! }
+      end
+
+      sign_out(authenticatable_class)
+
+      passwordless_session.claim! if Passwordless.restrict_token_reuse
+      raise Passwordless::Errors::SessionTimedOutError if passwordless_session.timed_out?
+
+      session.update(
+        session_key(passwordless_session.authenticatable_type) => passwordless_session.id
+      )
+
+      passwordless_session.authenticatable
     end
 
-    # Signs out user by deleting their encrypted cookie.
-    # @param (see #authenticate_by_cookie)
+    # Signs out user by deleting the session key.
+    # @param (see #authenticate_by_session)
     # @return [boolean] Always true
     def sign_out(authenticatable_class)
+      # Deprecated - cookies
       key = cookie_name(authenticatable_class)
       cookies.encrypted.permanent[key] = {value: nil}
       cookies.delete(key)
+      # /deprecated
+
+      session.delete session_key(authenticatable_class)
       true
     end
 
     # Saves request.original_url as the redirect location for a
     # passwordless Model.
-    # @param (see #authenticate_by_cookie)
+    # @param (see #authenticate_by_session)
     # @return [String] the redirect url that was just saved.
     def save_passwordless_redirect_location!(authenticatable_class)
-      session[session_key(authenticatable_class)] = request.original_url
+      session[redirect_session_key(authenticatable_class)] = request.original_url
     end
 
     # Resets the redirect_location to root_path by deleting the redirect_url
     # from session.
-    # @param (see #authenticate_by_cookie)
+    # @param (see #authenticate_by_session)
     # @return [String, nil] the redirect url that was just deleted,
     #   or nil if no url found for given Model.
     def reset_passwordless_redirect_location!(authenticatable_class)
-      session.delete session_key(authenticatable_class)
+      session.delete redirect_session_key(authenticatable_class)
     end
 
     private
 
-    def session_key(authenticatable_class)
-      :"passwordless_prev_location--#{authenticatable_class.base_class}"
+    def authenticatable_class_parameterized(authenticatable_class)
+      if authenticatable_class.is_a?(String)
+        authenticatable_class = authenticatable_class.constantize
+      end
+
+      authenticatable_class.base_class.to_s.parameterize
     end
 
+    def session_key(authenticatable_class)
+      :"passwordless_session_id_for_#{authenticatable_class_parameterized(authenticatable_class)}"
+    end
+
+    def redirect_session_key(authenticatable_class)
+      :"passwordless_prev_location--#{authenticatable_class_parameterized(authenticatable_class)}"
+    end
+
+    # Deprecated
     def cookie_name(authenticatable_class)
       :"#{authenticatable_class.base_class.to_s.underscore}_id"
     end

--- a/lib/passwordless/errors.rb
+++ b/lib/passwordless/errors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Passwordless
+  module Errors
+    # Raise this exception when a session is expired.
+    class SessionTimedOutError < StandardError; end
+
+    # Raise this exception when the token has been previously claimed
+    class TokenAlreadyClaimedError < StandardError; end
+  end
+end

--- a/test/controllers/deprecated_secrets_controller_test.rb
+++ b/test/controllers/deprecated_secrets_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DeprecatedSecretsControllerTest < ActionDispatch::IntegrationTest
+  def create_session_for(user)
+    Passwordless::Session.create!(
+      authenticatable: user,
+      remote_addr: "yes",
+      user_agent: "James Bond"
+    )
+  end
+
+  def cookie_key(authenticatable_class)
+    DeprecatedSecretsController.new.send(:cookie_key, authenticatable_class)
+  end
+
+  def login(passwordless_session)
+    post "/deprecated_fake_login", params: {
+      authenticatable_type: passwordless_session.authenticatable_type,
+      authenticatable_id: passwordless_session.authenticatable_id,
+    }
+  end
+
+  test "authenticate_by_cookies" do
+    user = User.create(email: "foo@example.com")
+    passwordless_session = create_session_for(user)
+    login(passwordless_session)
+
+    get "/deprecated_secret"
+    assert_equal 200, status
+  end
+end

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -12,6 +12,10 @@ module Passwordless
       )
     end
 
+    def session_key(authenticatable_class)
+      Passwordless::SessionsController.new.send(:session_key, authenticatable_class)
+    end
+
     test "requesting a magic link as an existing user" do
       User.create email: "a@a"
 
@@ -77,26 +81,26 @@ module Passwordless
 
     test "signing in via a token" do
       user = User.create email: "a@a"
-      session = create_session_for user
+      passwordless_session = create_session_for user
 
-      get "/users/sign_in/#{session.token}"
+      get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
       assert_equal 200, status
       assert_equal "/", path
-      assert_not_nil cookies[:user_id]
+      assert_not_nil session[session_key(user.class)]
     end
 
     test "signing in via a token as STI model" do
       admin = Admin.create email: "a@a"
-      session = create_session_for admin
+      passwordless_session = create_session_for admin
 
-      get "/users/sign_in/#{session.token}"
+      get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
       assert_equal 200, status
       assert_equal "/", path
-      assert_not_nil cookies[:user_id]
+      assert_not_nil session[session_key(admin.class)]
     end
 
     test "signing in and redirecting back" do
@@ -108,8 +112,8 @@ module Passwordless
       follow_redirect!
       assert_equal 200, status
 
-      session = create_session_for user
-      get "/users/sign_in/#{session.token}"
+      passwordless_session = create_session_for user
+      get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
       assert_equal 200, status
@@ -128,8 +132,8 @@ module Passwordless
       follow_redirect!
       assert_equal 200, status
 
-      session = create_session_for user
-      get "/users/sign_in/#{session.token}"
+      passwordless_session = create_session_for user
+      get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
       assert_equal "/", path
@@ -146,28 +150,28 @@ module Passwordless
     test "signing out" do
       user = User.create email: "a@a"
 
-      session = create_session_for user
-      get "/users/sign_in/#{session.token}"
-      assert_not_nil cookies[:user_id]
+      passwordless_session = create_session_for user
+      get "/users/sign_in/#{passwordless_session.token}"
+      assert_not_nil session[session_key(user.class)]
 
       get "/users/sign_out"
       follow_redirect!
 
       assert_equal 200, status
       assert_equal "/", path
-      assert cookies[:user_id].blank?
+      assert session[session_key(user.class)].blank?
     end
 
     test "trying to sign in with an timed out session" do
       user = User.create email: "a@a"
-      session = create_session_for user
-      session.update!(timeout_at: Time.current - 1.day)
+      passwordless_session = create_session_for user
+      passwordless_session.update!(timeout_at: Time.current - 1.day)
 
-      get "/users/sign_in/#{session.token}"
+      get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
       assert_match "Your session has expired", flash[:error]
-      assert_nil cookies[:user_id]
+      assert_nil session[session_key(user.class)]
       assert_equal 200, status
       assert_equal "/", path
     end
@@ -176,25 +180,39 @@ module Passwordless
       default = Passwordless.restrict_token_reuse
       Passwordless.restrict_token_reuse = true
       user = User.create email: "a@a"
-      session = create_session_for user
+      passwordless_session = create_session_for user
 
-      get "/users/sign_in/#{session.token}"
+      get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
-      assert_not_nil cookies[:user_id]
+      assert_not_nil session[session_key(user.class)]
 
       get "/users/sign_out"
       follow_redirect!
-      assert_equal true, session.reload.claimed?
+      assert_equal true, passwordless_session.reload.claimed?
 
-      get "/users/sign_in/#{session.token}"
+      get "/users/sign_in/#{passwordless_session.token}"
 
       assert_match "This link has already been used", flash[:error]
-      assert_equal cookies[:user_id], ""
+      assert_nil session[session_key(user.class)]
       follow_redirect!
       assert_equal 200, status
       assert_equal "/", path
 
       Passwordless.restrict_token_reuse = default
+    end
+
+    test "signing out removes cookies" do
+      user = User.create email: "a@a"
+
+      cookies[:user_id] = user.id
+      assert_not_nil cookies[:user_id]
+
+      get "/users/sign_out"
+      follow_redirect!
+
+      assert_equal 200, status
+      assert_equal "/", path
+      assert cookies[:user_id].blank?
     end
   end
 end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    @current_user ||= authenticate_by_cookie(User)
+    @current_user ||= authenticate_by_session(User)
   end
 
   def authenticate_user!

--- a/test/dummy/app/controllers/deprecated_secrets_controller.rb
+++ b/test/dummy/app/controllers/deprecated_secrets_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class DeprecatedSecretsController < ApplicationController
+  before_action :authenticate_user!, except: [:fake_login]
+
+  def fake_login
+    cookies.encrypted.permanent[cookie_name(fake_login_params[:authenticatable_type].constantize)] = params[:authenticatable_id]
+  end
+
+  def index
+    render plain: "shhhh! secrets!"
+  end
+
+  private
+
+  def fake_login_params
+    params.permit(:authenticatable_id, :authenticatable_type)
+  end
+
+  def current_user
+    @current_user ||= authenticate_by_cookie(User)
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   resources :registrations, only: %i[new create]
 
   get "/secret", to: "secrets#index"
+  get "/deprecated_secret", to: "deprecated_secrets#index"
+  post "/deprecated_fake_login", to: "deprecated_secrets#fake_login"
 
   root to: "users#index"
 end

--- a/test/models/passwordless/session_test.rb
+++ b/test/models/passwordless/session_test.rb
@@ -106,5 +106,17 @@ module Passwordless
         claimed_session.claim!
       end
     end
+
+    test "valid_session? - valid session" do
+      valid_session = create_session
+
+      assert_equal valid_session.valid_session?, true
+    end
+
+    test "valid_session? - invalid session" do
+      invalid_session = create_session timeout_at: 2.years.ago, expires_at: 2.years.ago
+
+      assert_equal invalid_session.valid_session?, false
+    end
   end
 end

--- a/test/models/passwordless/session_test.rb
+++ b/test/models/passwordless/session_test.rb
@@ -102,7 +102,7 @@ module Passwordless
     test "claim! - with claimed session" do
       claimed_session = create_session claimed_at: 1.hour.ago
 
-      assert_raises(Passwordless::Session::TokenAlreadyClaimedError) do
+      assert_raises(Passwordless::Errors::TokenAlreadyClaimedError) do
         claimed_session.claim!
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "simplecov"
-SimpleCov.start
+SimpleCov.start do
+  add_filter "test/dummy"
+end
 
 if ENV["CI"]
   require "codecov"


### PR DESCRIPTION
Fixes #44

I've refactored the sign/in out flow to use the session rather than a cookie.

Couple of things of note:
- This introduces an n+1 query, loading the Passwordless::Session, then the `authenticatable`
  - Could possibly store the Authenticatable in the session as well, but that adds complexity
  - Could employ some Rails caching to prevent loading the Session each time
- This is a breaking change in that `ControllerHelpers.passwordless_for` is now required to set up controllers with the correct resource to authenticate against, however I've made some of the other method params optional. Wondering if it's better to just remove the superfluous params?
- Instead of deprecating `ControllerHelpers#authenticate_by_cookie`, what do you think of removing it since it's a breaking change?

Let me know what you think!