### PR TITLE
Fix session expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixes session availability wrongly determined by _timeout_ not _expiry_ ([#61](https://github.com/mikker/passwordless/pull/61))
+
 ## 0.8.1 (2019-08-14)
 
 ### Fixed

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -19,7 +19,7 @@ module Passwordless
     before_validation :set_defaults
 
     scope :available, lambda {
-      where("timeout_at > ?", Time.current)
+      where("expires_at > ?", Time.current)
     }
 
     def self.valid
@@ -47,7 +47,7 @@ module Passwordless
     end
 
     def available?
-      !timed_out? && !expired?
+      !expired?
     end
 
     private

--- a/test/models/passwordless/session_test.rb
+++ b/test/models/passwordless/session_test.rb
@@ -16,7 +16,7 @@ module Passwordless
 
     test "scope: available" do
       available = create_session
-      _timed_out = create_session timeout_at: 1.hour.ago
+      _timed_out = create_session expires_at: 1.hour.ago
 
       assert_equal [available], Session.available.all
     end
@@ -114,7 +114,7 @@ module Passwordless
     end
 
     test "available? - when unavailable" do
-      unavailable_session = create_session timeout_at: 2.years.ago, expires_at: 2.years.ago
+      unavailable_session = create_session expires_at: 2.years.ago
 
       refute unavailable_session.available?
     end


### PR DESCRIPTION
Session availability is wrongly defined by timeout instead of expiry. Damn, those two get confused so easily 🙄