### PR TITLE
Feature: default redirect

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -55,7 +55,7 @@ module Passwordless
       redirect_to main_app.root_path
     rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
-      redirect_to main_app.root_path
+      redirect_to Passwordless.default_redirect_path
     end
 
     # match '/sign_out', via: %i[get delete].

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -12,6 +12,7 @@ module Passwordless
   mattr_accessor(:restrict_token_reuse) { false }
   mattr_accessor(:redirect_back_after_sign_in) { true }
   mattr_accessor(:mounted_as) { :configured_when_mounting_passwordless }
+  mattr_accessor(:default_redirect_path) { '/' }
 
   mattr_accessor(:expires_at) { lambda { 1.year.from_now } }
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -181,6 +181,7 @@ module Passwordless
     end
 
     test "trying to sign in with an timed out session" do
+      default_redirect_path = Passwordless.default_redirect_path
       user = User.create email: "a@a"
       passwordless_session = create_session_for user
       passwordless_session.update!(timeout_at: Time.current - 1.day)
@@ -191,7 +192,7 @@ module Passwordless
       assert_match "Your session has expired", flash[:error]
       assert_nil session[Helpers.session_key(user.class)]
       assert_equal 200, status
-      assert_equal "/", path
+      assert_equal default_redirect_path, path
     end
 
     test "trying to use a claimed token" do


### PR DESCRIPTION
This PR is about #19 and #21 . But I'm not sure of a couple things:
- If https://github.com/mikker/passwordless/blob/master/app/controllers/passwordless/sessions_controller.rb#L58 is the only place where that custom path is needed (why not if token is already claimed, for ex.?)
- If you liked the config attr name `default_redirect_path`.

Well, would appreciate your guidance on this. 

Thanks!