### PR TITLE
Feature: configurable redirect

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -74,8 +74,19 @@ module Passwordless
     def passwordless_success_redirect_path
       return Passwordless.success_redirect_path unless Passwordless.redirect_back_after_sign_in
 
-      redirect_url = reset_passwordless_redirect_location!(authenticatable_class)
-      params[:url] || redirect_url || Passwordless.success_redirect_path
+      begin
+        uri = URI.parse(params[:destination_path])
+        query_redirect_path = StringIO.new
+        query_redirect_path << uri.path
+        query_redirect_path << '?' << uri.query if uri.query.present?
+        query_redirect_path << '#' << uri.fragment if uri.fragment.present?
+        query_redirect_path = query_redirect_path.string
+      rescue URI::InvalidURIError
+        query_redirect_path = nil
+      end
+
+      session_redirect_url = reset_passwordless_redirect_location!(authenticatable_class)
+      query_redirect_path || session_redirect_url || Passwordless.success_redirect_path
     end
 
     private

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -44,13 +44,13 @@ module Passwordless
       BCrypt::Password.create(params[:token])
       sign_in passwordless_session
 
-      redirect_to passwordless_redirect_path || passwordless_default_redirect_path
+      redirect_to passwordless_success_redirect_path
     rescue Errors::TokenAlreadyClaimedError
       flash[:error] = I18n.t(".passwordless.sessions.create.token_claimed")
-      redirect_to passwordless_default_redirect_path
+      redirect_to passwordless_failure_redirect_path
     rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
-      redirect_to passwordless_default_redirect_path
+      redirect_to passwordless_failure_redirect_path
     end
 
     # match '/sign_out', via: %i[get delete].
@@ -58,20 +58,24 @@ module Passwordless
     # @see ControllerHelpers#sign_out
     def destroy
       sign_out authenticatable_class
-      redirect_to passwordless_default_redirect_path
+      redirect_to passwordless_sign_out_redirect_path
     end
 
     protected
 
-    def passwordless_default_redirect_path
-      Passwordless.default_redirect_path
+    def passwordless_sign_out_redirect_path
+      Passwordless.sign_out_redirect_path
     end
 
-    def passwordless_redirect_path
+    def passwordless_failure_redirect_path
+      Passwordless.failure_redirect_path
+    end
+
+    def passwordless_success_redirect_path
       return nil unless Passwordless.redirect_back_after_sign_in
 
       redirect_url = reset_passwordless_redirect_location!(authenticatable_class)
-      params[:url] || redirect_url
+      params[:url] || redirect_url || Passwordless.success_redirect_path
     end
 
     private

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -72,7 +72,7 @@ module Passwordless
     end
 
     def passwordless_success_redirect_path
-      return nil unless Passwordless.redirect_back_after_sign_in
+      return Passwordless.success_redirect_path unless Passwordless.redirect_back_after_sign_in
 
       redirect_url = reset_passwordless_redirect_location!(authenticatable_class)
       params[:url] || redirect_url || Passwordless.success_redirect_path

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -42,20 +42,15 @@ module Passwordless
     def show
       # Make it "slow" on purpose to make brute-force attacks more of a hassle
       BCrypt::Password.create(params[:token])
-
-      destination =
-        Passwordless.redirect_back_after_sign_in &&
-        reset_passwordless_redirect_location!(authenticatable_class)
-
       sign_in passwordless_session
 
-      redirect_to destination || main_app.root_path
+      redirect_to passwordless_redirect_path || Passwordless.default_redirect_path
     rescue Errors::TokenAlreadyClaimedError
       flash[:error] = I18n.t(".passwordless.sessions.create.token_claimed")
-      redirect_to main_app.root_path
+      redirect_to Passwordless.default_redirect_path
     rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
-      redirect_to main_app.root_path
+      redirect_to Passwordless.default_redirect_path
     end
 
     # match '/sign_out', via: %i[get delete].
@@ -63,7 +58,15 @@ module Passwordless
     # @see ControllerHelpers#sign_out
     def destroy
       sign_out authenticatable_class
-      redirect_to main_app.root_path
+      redirect_to Passwordless.default_redirect_path
+    end
+
+    protected
+
+    def passwordless_redirect_path
+      return nil unless Passwordless.redirect_back_after_sign_in
+
+      reset_passwordless_redirect_location!(authenticatable_class)
     end
 
     private

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -66,7 +66,8 @@ module Passwordless
     def passwordless_redirect_path
       return nil unless Passwordless.redirect_back_after_sign_in
 
-      reset_passwordless_redirect_location!(authenticatable_class)
+      redirect_url = reset_passwordless_redirect_location!(authenticatable_class)
+      params[:url] || redirect_url
     end
 
     private

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -44,13 +44,13 @@ module Passwordless
       BCrypt::Password.create(params[:token])
       sign_in passwordless_session
 
-      redirect_to passwordless_redirect_path || Passwordless.default_redirect_path
+      redirect_to passwordless_redirect_path || passwordless_default_redirect_path
     rescue Errors::TokenAlreadyClaimedError
       flash[:error] = I18n.t(".passwordless.sessions.create.token_claimed")
-      redirect_to Passwordless.default_redirect_path
+      redirect_to passwordless_default_redirect_path
     rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
-      redirect_to Passwordless.default_redirect_path
+      redirect_to passwordless_default_redirect_path
     end
 
     # match '/sign_out', via: %i[get delete].
@@ -58,10 +58,14 @@ module Passwordless
     # @see ControllerHelpers#sign_out
     def destroy
       sign_out authenticatable_class
-      redirect_to Passwordless.default_redirect_path
+      redirect_to passwordless_default_redirect_path
     end
 
     protected
+
+    def passwordless_default_redirect_path
+      Passwordless.default_redirect_path
+    end
 
     def passwordless_redirect_path
       return nil unless Passwordless.redirect_back_after_sign_in

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -71,22 +71,18 @@ module Passwordless
       Passwordless.failure_redirect_path
     end
 
+    def passwordless_query_redirect_path
+      query_redirect_uri = URI(params[:destination_path])
+      query_redirect_uri.to_s if query_redirect_uri.host.nil? || query_redirect_uri.host == URI(request.url).host
+    rescue URI::InvalidURIError, ArgumentError
+      nil
+    end
+
     def passwordless_success_redirect_path
       return Passwordless.success_redirect_path unless Passwordless.redirect_back_after_sign_in
 
-      begin
-        uri = URI.parse(params[:destination_path])
-        query_redirect_path = StringIO.new
-        query_redirect_path << uri.path
-        query_redirect_path << '?' << uri.query if uri.query.present?
-        query_redirect_path << '#' << uri.fragment if uri.fragment.present?
-        query_redirect_path = query_redirect_path.string
-      rescue URI::InvalidURIError
-        query_redirect_path = nil
-      end
-
       session_redirect_url = reset_passwordless_redirect_location!(authenticatable_class)
-      query_redirect_path || session_redirect_url || Passwordless.success_redirect_path
+      passwordless_query_redirect_path || session_redirect_url || Passwordless.success_redirect_path
     end
 
     private

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -15,7 +15,7 @@ module Passwordless
 
   mattr_accessor(:expires_at) { lambda { 1.year.from_now } }
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
-  mattr_accessor(:redirect_on_failure) { '/' }
+  mattr_accessor(:default_redirect_path) { '/' }
 
   mattr_accessor(:after_session_save) do
     lambda { |session, _request| Mailer.magic_link(session).deliver_now }

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -15,6 +15,7 @@ module Passwordless
 
   mattr_accessor(:expires_at) { lambda { 1.year.from_now } }
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
+  mattr_accessor(:redirect_on_failure) { '/' }
 
   mattr_accessor(:after_session_save) do
     lambda { |session, _request| Mailer.magic_link(session).deliver_now }

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -15,7 +15,9 @@ module Passwordless
 
   mattr_accessor(:expires_at) { lambda { 1.year.from_now } }
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
-  mattr_accessor(:default_redirect_path) { '/' }
+  mattr_accessor(:success_redirect_path) { '/' }
+  mattr_accessor(:failure_redirect_path) { '/' }
+  mattr_accessor(:signout_redirect_path) { '/' }
 
   mattr_accessor(:after_session_save) do
     lambda { |session, _request| Mailer.magic_link(session).deliver_now }

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -17,7 +17,7 @@ module Passwordless
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
   mattr_accessor(:success_redirect_path) { '/' }
   mattr_accessor(:failure_redirect_path) { '/' }
-  mattr_accessor(:signout_redirect_path) { '/' }
+  mattr_accessor(:sign_out_redirect_path) { '/' }
 
   mattr_accessor(:after_session_save) do
     lambda { |session, _request| Mailer.magic_link(session).deliver_now }

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -104,7 +104,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.success_redirect_path, path
+      assert_equal "/", path
       assert_not_nil session[Helpers.session_key(user.class)]
     end
 
@@ -116,7 +116,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.success_redirect_path, path
+      assert_equal "/", path
       assert_not_nil session[Helpers.session_key(admin.class)]
     end
 
@@ -192,7 +192,7 @@ module Passwordless
       get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
-      assert_equal Passwordless.success_redirect_path, path
+      assert_equal "/", path
 
       Passwordless.redirect_back_after_sign_in = default
     end
@@ -214,7 +214,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.sign_out_redirect_path, path
+      assert_equal "/", path
       assert session[Helpers.session_key(user.class)].blank?
     end
 
@@ -229,7 +229,7 @@ module Passwordless
       assert_match "Your session has expired", flash[:error]
       assert_nil session[Helpers.session_key(user.class)]
       assert_equal 200, status
-      assert_equal Passwordless.failure_redirect_path, path
+      assert_equal "/", path
     end
 
     test "trying to use a claimed token" do
@@ -252,7 +252,7 @@ module Passwordless
       assert_nil session[Helpers.session_key(user.class)]
       follow_redirect!
       assert_equal 200, status
-      assert_equal Passwordless.failure_redirect_path, path
+      assert_equal "/", path
 
       Passwordless.restrict_token_reuse = default
     end
@@ -267,7 +267,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.sign_out_redirect_path, path
+      assert_equal "/", path
       assert cookies[:user_id].blank?
     end
   end

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -104,7 +104,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.success_redirect_path, path
       assert_not_nil session[Helpers.session_key(user.class)]
     end
 
@@ -116,7 +116,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.success_redirect_path, path
       assert_not_nil session[Helpers.session_key(admin.class)]
     end
 
@@ -172,7 +172,7 @@ module Passwordless
       get "/users/sign_in/#{passwordless_session.token}"
       follow_redirect!
 
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.success_redirect_path, path
 
       Passwordless.redirect_back_after_sign_in = default
     end
@@ -194,7 +194,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.sign_out_redirect_path, path
       assert session[Helpers.session_key(user.class)].blank?
     end
 
@@ -209,7 +209,7 @@ module Passwordless
       assert_match "Your session has expired", flash[:error]
       assert_nil session[Helpers.session_key(user.class)]
       assert_equal 200, status
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.failure_redirect_path, path
     end
 
     test "trying to use a claimed token" do
@@ -232,7 +232,7 @@ module Passwordless
       assert_nil session[Helpers.session_key(user.class)]
       follow_redirect!
       assert_equal 200, status
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.failure_redirect_path, path
 
       Passwordless.restrict_token_reuse = default
     end
@@ -247,7 +247,7 @@ module Passwordless
       follow_redirect!
 
       assert_equal 200, status
-      assert_equal Passwordless.default_redirect_path, path
+      assert_equal Passwordless.sign_out_redirect_path, path
       assert cookies[:user_id].blank?
     end
   end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :registrations, only: %i[new create]
 
   get "/secret", to: "secrets#index"
+  get "/secret-alt", to: "secrets#index"
   get "/deprecated_secret", to: "deprecated_secrets#index"
   post "/deprecated_fake_login", to: "deprecated_secrets#fake_login"
 

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -16,7 +16,7 @@ class NavigationTest < ActionDispatch::IntegrationTest
     assert_equal "Not worthy!", flash["error"]
     follow_redirect!
     assert_equal 200, status
-    assert_equal "/", path
+    assert_equal Passwordless.default_redirect_path, path
 
     # Load login form
     get "/users/sign_in"

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -16,7 +16,7 @@ class NavigationTest < ActionDispatch::IntegrationTest
     assert_equal "Not worthy!", flash["error"]
     follow_redirect!
     assert_equal 200, status
-    assert_equal Passwordless.default_redirect_path, path
+    assert_equal Passwordless.failure_redirect_path, path
 
     # Load login form
     get "/users/sign_in"

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -16,7 +16,7 @@ class NavigationTest < ActionDispatch::IntegrationTest
     assert_equal "Not worthy!", flash["error"]
     follow_redirect!
     assert_equal 200, status
-    assert_equal Passwordless.failure_redirect_path, path
+    assert_equal "/", path
 
     # Load login form
     get "/users/sign_in"


### PR DESCRIPTION
This contains the changes in PR #67, but allows further customisation, and also applied the customised redirect to all failures, instead of just token reuse. This also addresses #19 and #21 

 - Sign out redirection can be configured with `sign_out_redirect_path`
 - Failure redirection with `failure_redirect_path`
 - Success redirection with `success_redirect_path`
 - Success redirection can also be set with the `url` query parameter.

Success redirection has this priority
`params[:url]` > `reset_passwordless_redirect_location` > `Passwordless.success_redirect_path`

In theory I've also set it up so that you can override the functions that fetch these redirects for more complicated/customisable redirection, but I haven't tested that.

All tests have been updated and pass.