### PR TITLE
mailer: allow configuration option to change the Mailer's superclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Option to customize mailer inheritance with a new configuration `parent_mailer` ([#82](https://github.com/mikker/passwordless/pull/82))
+
 ## 0.9.0 (2019-12-19)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The default values are shown below. It's recommended to only include the ones th
 
 ```ruby
 Passwordless.default_from_address = "CHANGE_ME@example.com"
+Passwordless.parent_mailer = "ActionMailer::Base"
 Passwordless.token_generator = Passwordless::UrlSafeBase64Generator.new # Used to generate magic link tokens.
 Passwordless.restrict_token_reuse = false # By default a magic link token can be used multiple times.
 Passwordless.redirect_back_after_sign_in = true # When enabled the user will be redirected to their previous page, or a page specified by the `destination_path` query parameter, if available.

--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -2,7 +2,7 @@
 
 module Passwordless
   # The mailer responsible for sending Passwordless' mails.
-  class Mailer < ActionMailer::Base
+  class Mailer < Passwordless.parent_mailer.constantize
     default from: Passwordless.default_from_address
 
     # Sends a magic link (secret token) email.
@@ -11,7 +11,7 @@ module Passwordless
       @session = session
 
       @magic_link = send(Passwordless.mounted_as)
-        .token_sign_in_url(session.token)
+                      .token_sign_in_url(session.token)
 
       email_field = @session.authenticatable.class.passwordless_email_field
       mail(

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -7,6 +7,7 @@ require "passwordless/url_safe_base_64_generator"
 
 # The main Passwordless module
 module Passwordless
+  mattr_accessor(:parent_mailer) { "ActionMailer::Base" }
   mattr_accessor(:default_from_address) { "CHANGE_ME@example.com" }
   mattr_accessor(:token_generator) { UrlSafeBase64Generator.new }
   mattr_accessor(:restrict_token_reuse) { false }


### PR DESCRIPTION
This PR adds a `parent_mailer` configuration option to the Engine
which can receive a Mailer class from which the passwordless mailer
will inherit from.

By default the Mailer inherits from `ACtionMailer::Base` but allowing
the superclass to be configurable gives users the possibility to
inherit from their own `ApplicationMailer` class for instance.

This is handy to be able to share users' mailer configuration between
all mailers (including the own provided by Passwordless engine).

About #78. These changes are directly inspired by [Devise](https://github.com/heartcombo/devise/pull/2223/files).