### PR TITLE
reset session at sign_in for protect from session fixation attacks.

### DIFF
--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -89,6 +89,10 @@ module Passwordless
 
       raise Passwordless::Errors::SessionTimedOutError if passwordless_session.timed_out?
 
+      old_session = session.dup.to_hash
+      reset_session
+      old_session.each_pair { |k, v| session[k.to_sym] = v }
+
       key = session_key(passwordless_session.authenticatable_type)
       session[key] = passwordless_session.id
 

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -118,6 +118,18 @@ module Passwordless
       assert_not_nil session[Helpers.session_key(user.class)]
     end
 
+    test("reset session id when signing in via a token") do
+      user = User.create(email: "a@a")
+      passwordless_session = create_session_for(user)
+
+      get "/users/sign_in/#{passwordless_session.token}"
+      old_session_id = @request.session_options[:id].to_s
+      get "/users/sign_in/#{passwordless_session.token}"
+      new_session_id = @request.session_options[:id].to_s
+
+      assert_not_equal old_session_id, new_session_id
+    end
+
     test("signing in via a token as STI model") do
       admin = Admin.create(email: "a@a")
       passwordless_session = create_session_for(admin)


### PR DESCRIPTION
It is recommended to reset the session at sign in for protect from session fixation attacks.
So  reseted session in `Passwordless::ControllerHelpers#sign_in`.

> 2.7 Session Fixation - Countermeasures
> One line of code will protect you from session fixation.
> The most effective countermeasure is to issue a new session identifier and declare the old one invalid after a successful login.
> That way, an attacker cannot use the fixed session identifier.
> This is a good countermeasure against session hijacking, as well.
> Here is how to create a new session in Rails:
> reset_session
> https://guides.rubyonrails.org/security.html#session-fixation-countermeasures

ex. `Sorcery::Controller::InstanceMethods#login` in Sorcery

``` ruby
old_session = session.dup.to_hash
reset_sorcery_session
old_session.each_pair do |k, v|
  session[k.to_sym] = v
end
```

https://github.com/Sorcery/sorcery/blob/6fdc703416b3ff8d05708b05d5a8228ab39032a5/lib/sorcery/controller.rb#L52-L56

How about this PR?

fixed https://github.com/mikker/passwordless/issues/107