### PR TITLE
Use GH actions for status badge instead of Travis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br />
 </p>
 
-[![Travis](https://travis-ci.org/mikker/passwordless.svg?branch=master)](https://travis-ci.org/mikker/passwordless) [![Rubygems](https://img.shields.io/gem/v/passwordless.svg)](https://rubygems.org/gems/passwordless) [![codecov](https://codecov.io/gh/mikker/passwordless/branch/master/graph/badge.svg)](https://codecov.io/gh/mikker/passwordless)
+[![CI](https://github.com/mikker/passwordless/actions/workflows/ci.yml/badge.svg)](https://github.com/mikker/passwordless/actions/workflows/ci.yml) [![Rubygems](https://img.shields.io/gem/v/passwordless.svg)](https://rubygems.org/gems/passwordless) [![codecov](https://codecov.io/gh/mikker/passwordless/branch/master/graph/badge.svg)](https://codecov.io/gh/mikker/passwordless)
 
 Add authentication to your Rails app without all the icky-ness of passwords.
 


### PR DESCRIPTION
This is a PR to changed to status badge to show the result of the GH action.

How about this PR?

## Description

The CI now uses the GH action instead of Travis, but the result badge was still Travis, so I fixed it.

related: https://github.com/mikker/passwordless/pull/109

## Test

I have confirmed that the Github Action result badge appears in my repository.

https://github.com/madogiwa0124/passwordless/blob/migrate-to-gh-action-badge/README.md

