### PR TITLE
use ActiveSupport::FileUpdateChecker in the development environment.

### DIFF
--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -58,8 +58,8 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # routes, locales, etc.
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true


### PR DESCRIPTION
This is a PR to changed to `ActiveSupport::FileUpdateChecker` from `ActiveSupport::EventedFileUpdateChecker`.

How about this PR?

## Description

The `ActiveSupport::EventedFileUpdateChecker` depends on [listen](https://github.com/guard/listen), but since it is not installed,
an exception is thrown when trying to start the development environment.

```
bin/rails s
=> Booting WEBrick
=> Rails 6.1.4.1 application starting in development http://localhost:3000
=> Run `bin/rails server --help` for more startup options
Exiting
passwordless/vendor/bundle/ruby/3.0.0/gems/zeitwerk-2.5.1/lib/zeitwerk/kernel.rb:35:in `require': cannot load such file -- listen (LoadError)
```

Therefore, use `ActiveSupport::FileUpdateChecker` which does not depend on listen.

> config.file_watcher
> Rails ships with ActiveSupport::FileUpdateChecker, the default
> https://guides.rubyonrails.org/v6.1/configuring.html#rails-general-configuration


## Test

I was able to confirm that the boot succeeded on my local.

```
bin/rails s
=> Booting WEBrick
=> Rails 6.1.4.1 application starting in development http://localhost:3000
=> Run `bin/rails server --help` for more startup options
[2021-12-19 18:19:45] INFO  WEBrick 1.7.0
[2021-12-19 18:19:45] INFO  ruby 3.0.0 (2020-12-25) [x86_64-darwin18]
[2021-12-19 18:19:45] INFO  WEBrick::HTTPServer#start: pid=94148 port=3000
```