### PR TITLE
Ensure that CI is executed for PRs from forked repositories.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This is a PR to changed to CI trigger from push only.

How about this PR?

## Description

Currently, CI is only triggered by push, so PR from a forked repository will not run CI.
Therefore, added `pull_request` in `on`.

Also, if simply add `pull_request`, it will be executed twice with `push`,
so we modified `push` to be executed only in the `master` branch.

related: https://github.com/mikker/passwordless/pull/109

## Test

In my repository, I have confirmed that CI runs "when the PR is created" and "when it is merged into master".

* when the PR is created : https://github.com/madogiwa0124/passwordless/runs/4595115995
* when it is merged into master : https://github.com/madogiwa0124/passwordless/actions/runs/1607003274

## References

> This will prevent builds from happening twice when somebody opens a pull request against master and then pushes updates to their branch. For example:
> ```yaml
> on:
>  push:
>    branches:
>    - master
>  pull_request:
>    branches:
>    - master
> ```
> https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/2

I didn't feel it was necessary to limit it to those aimed at the master branch, so I made sure to run CI on all pull requests.

If it is better to focus only on master, I will modify it as per the sample 😃 