### PR TITLE
In testing, use the Example domains.

### DIFF
--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -190,7 +190,7 @@ module Passwordless
     test("signing in and redirecting via insecure query parameter") do
       user = User.create!(email: "a@a")
       passwordless_session = create_session_for(user)
-      get "/users/sign_in/#{passwordless_session.token}?destination_path=http://google.com/secret-alt"
+      get "/users/sign_in/#{passwordless_session.token}?destination_path=http://insecure.example.org/secret-alt"
       follow_redirect!
 
       assert_equal 200, status


### PR DESCRIPTION
There was a part in the test code where the Example domains was not used, so it has been fixed.

> Example domains
> As described in RFC 2606 and RFC 6761, a number of domains such as `example.com` and `example.org` are maintained for documentation purposes. These domains may be used as illustrative examples in documents without prior coordination with us. They are not available for registration or transfer.
> https://www.iana.org/domains/reserved

How about PR?