### PR TITLE
Always redirect magic link requests back to the sign_in page and render generic flash

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -17,7 +17,7 @@ module Passwordless
 
     # post '/sign_in'
     #   Creates a new Session record then sends the magic link
-    #   renders sessions/create.html.erb.
+    #   redirects to sign in page with generic flash message.
     # @see Mailer#magic_link Mailer#magic_link
     def create
       @resource = find_authenticatable
@@ -29,11 +29,10 @@ module Passwordless
         else
           Passwordless.after_session_save.call(session)
         end
-
-        render :create, status: :ok
-      else
-        render :create, status: :unprocessable_entity
       end
+
+      flash[:notice] = I18n.t('passwordless.sessions.create.email_sent_if_record_found')
+      redirect_to(sign_in_path)
     end
 
     # get '/sign_in/:token'

--- a/app/views/passwordless/sessions/create.html.erb
+++ b/app/views/passwordless/sessions/create.html.erb
@@ -1,1 +1,0 @@
-<p><%= I18n.t('passwordless.sessions.create.email_sent_if_record_found') %></p>

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -27,7 +27,8 @@ module Passwordless
         params: {passwordless: {email: "A@a"}},
         headers: {:"User-Agent" => "an actual monkey"}
       )
-      assert_equal 200, status
+      assert_equal 302, status
+      assert_equal "/users/sign_in", path
 
       assert_equal 1, ActionMailer::Base.deliveries.size
     end
@@ -44,7 +45,7 @@ module Passwordless
         params: {passwordless: {email: "A@a"}},
         headers: {:"User-Agent" => "an actual monkey"}
       )
-      assert_equal 200, status
+      assert_equal 302, status
 
       assert_equal true, called
 
@@ -63,7 +64,7 @@ module Passwordless
         params: {passwordless: {email: "A@a"}},
         headers: {:"User-Agent" => "an actual monkey"}
       )
-      assert_equal 200, status
+      assert_equal 302, status
 
       assert_equal true, called
 
@@ -79,7 +80,7 @@ module Passwordless
         params: {passwordless: {email: "invalidemail"}},
         headers: {:"User-Agent" => "an actual monkey"}
       )
-      assert_equal 422, status
+      assert_equal 302, status
 
       assert_equal 0, ActionMailer::Base.deliveries.size
     end
@@ -97,7 +98,7 @@ module Passwordless
         params: {passwordless: {email: "overriden_email@example"}},
         headers: {:"User-Agent" => "an actual monkey"}
       )
-      assert_equal 200, status
+      assert_equal 302, status
 
       assert_equal 1, ActionMailer::Base.deliveries.size
 

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -31,8 +31,8 @@ class NavigationTest < ActionDispatch::IntegrationTest
 
       headers: {"HTTP_USER_AGENT" => "Mosaic v.1"}
     )
-    assert_equal 200, status
-    assert response.body.include?("If we found you in the system")
+    assert_equal 302, status
+    assert flash["notice"].include?("If we found you in the system")
 
     # Expect session created for alice
     user_session = Passwordless::Session.find_by!(authenticatable: alice)


### PR DESCRIPTION
Hey @mikker,

I realized that I couldn't get magic link requests to work at all without always doing a redirect for Turbo. Turbo is always going to complain about the response needing to be a redirect when it's a simple render call without a `status: :unprocessable_entity`. 

If `sessions/create.html.erb` is removed though I was thinking it might be nice to be able to specify a redirect location instead of the default or some way to detect that a magic link was just requested after the redirect. 

Related to: https://github.com/mikker/passwordless/pull/116
Root issue: https://github.com/hotwired/turbo-rails/issues/12