### PR TITLE
Add a simple view generator for #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ end
 
 ### Providing your own templates
 
-Override `passwordless`' bundled views by adding your own. `passwordless` has 2 action views and 1 mailer view:
+Override `passwordless`' bundled views by adding your own. You can manually copy the specific views that you need or copy them to your application with `rails generate passwordless:views`.
+
+`passwordless` has 2 action views and 1 mailer view:
 
 ```sh
 # the form where the user inputs their email address

--- a/lib/generators/passwordless/views_generator.rb
+++ b/lib/generators/passwordless/views_generator.rb
@@ -1,0 +1,15 @@
+require 'rails/generators'
+
+module Passwordless
+  module Generators
+    class ViewsGenerator < Rails::Generators::Base
+      source_root File.expand_path('../../../app/views/passwordless', __dir__)
+
+      def install
+        copy_file 'mailer/magic_link.text.erb', 'app/views/passwordless/mailer/magic_link.text.erb'
+        copy_file 'sessions/new.html.erb', 'app/views/passwordless/sessions/new.html.erb'
+        copy_file 'sessions/create.html.erb', 'app/views/passwordless/sessions.create.html.erb'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This utilizes Thor's `copy_file` method which utilizes the same generator flow of copying a file and checking for conflicts if the view files already exist. This mirrors exactly what's currently in the readme for utilizing your own views and I've added a mention to this generator task as well. 

```
$ rails generate passwordless:views
   identical  app/views/passwordless/mailer/magic_link.text.erb
   identical  app/views/passwordless/sessions/new.html.erb
    conflict  app/views/passwordless/sessions.create.html.erb
Overwrite /Users/nick/src/sandbox/blah/app/views/passwordless/sessions.create.html.erb? (enter "h" for help) [Ynaqdhm] y
       force  app/views/passwordless/sessions.create.html.erb
```