### PR TITLE
introduce a :paranoid flag to prevent leaking the existence of an email in the db (POC)

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -32,7 +32,8 @@ module Passwordless
 
         render :create, status: :ok
       else
-        render :create, status: :unprocessable_entity
+        render :create, status: :ok if Passwordless.paranoid
+        render :create, status: :unprocessable_entity unless Passwordless.paranoid
       end
     end
 

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -11,6 +11,7 @@ module Passwordless
   mattr_accessor(:default_from_address) { "CHANGE_ME@example.com" }
   mattr_accessor(:token_generator) { UrlSafeBase64Generator.new }
   mattr_accessor(:restrict_token_reuse) { false }
+  mattr_accessor(:paranoid) { false }
   mattr_accessor(:redirect_back_after_sign_in) { true }
   mattr_accessor(:mounted_as) { :configured_when_mounting_passwordless }
 

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -76,12 +76,31 @@ module Passwordless
 
       post(
         "/users/sign_in",
-        params: {passwordless: {email: "invalidemail"}},
-        headers: {:"User-Agent" => "an actual monkey"}
+        params: { passwordless: { email: "invalidemail" } },
+        headers: { :"User-Agent" => "an actual monkey" },
       )
       assert_equal 422, status
 
       assert_equal 0, ActionMailer::Base.deliveries.size
+    end
+
+    test("requesting a magic link as an unknown user when paranoid: true") do
+      default = Passwordless.paranoid
+
+      get "/users/sign_in"
+      assert_equal 200, status
+
+      Passwordless.paranoid = true
+
+      post(
+        "/users/sign_in",
+        params: { passwordless: { email: "invalidemail" } },
+        headers: { :"User-Agent" => "an actual monkey" },
+      )
+      assert_equal 200, status
+      assert_equal 0, ActionMailer::Base.deliveries.size
+
+      Passwordless.paranoid = default
     end
 
     test("requesting a magic link with overridden fetch method") do


### PR DESCRIPTION
Wanted to try out a proof of concept after reading [this issue](https://github.com/mikker/passwordless/issues/131). 



