### PR TITLE
require email on sign in

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -108,6 +108,8 @@ module Passwordless
 
     def find_authenticatable
       email = params[:passwordless][email_field].downcase.strip
+      
+      return unless email.match(URI::MailTo::EMAIL_REGEXP)
 
       if authenticatable_class.respond_to?(:fetch_resource_for_passwordless)
         authenticatable_class.fetch_resource_for_passwordless(email)

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -84,6 +84,24 @@ module Passwordless
       assert_equal 0, ActionMailer::Base.deliveries.size
     end
 
+    test("requesting a magic link with an empty email") do
+      post(
+        "/users/sign_in",
+        params: {passwordless: {email: ""}},
+        headers: {:"User-Agent" => "an actual monkey"}
+      )
+      assert_equal 422, status
+    end
+
+    test("requesting a magic link with an invalid email") do
+      post(
+        "/users/sign_in",
+        params: {passwordless: {email: "false_email"}},
+        headers: {:"User-Agent" => "an actual monkey"}
+      )
+      assert_equal 422, status
+    end
+
     test("requesting a magic link with overridden fetch method") do
       def User.fetch_resource_for_passwordless(email)
         User.find_or_create_by(email: email)


### PR DESCRIPTION
Added a check to prevent user submitting an invalid email
github issue: https://github.com/mikker/passwordless/issues/129