### PR TITLE
Allow re-sending of magic link emails

### DIFF
--- a/app/views/passwordless/sessions/show.html.erb
+++ b/app/views/passwordless/sessions/show.html.erb
@@ -1,0 +1,7 @@
+<%= form_with model: @session, method: :post, url: send(Passwordless.mounted_as).sign_in_path, data: { turbo: 'false' } do |f| %>
+  <%= hidden_field_tag 'passwordless[destination_path]', @destination_path %>
+  <%= hidden_field_tag 'passwordless[token]', @session.token %>
+  <%= I18n.t('passwordless.sessions.show.explanation') %>
+  <%= f.submit I18n.t('passwordless.sessions.show.submit') %>
+<% end %>
+<%= link_to I18n.t('passwordless.sessions.show.new'), send(Passwordless.mounted_as).sign_in_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,10 @@ en:
         token_claimed: "This link has already been used, try requesting the link again"
       new:
         submit: 'Send magic link'
+      show:
+        explanation: 'Your magic link is no longer valid, but you can request a new one.'
+        submit: 'Resend magic link'
+        new: 'Or go to the sign in page.'
     mailer:
       subject: "Your magic link ✨"
       magic_link: "Here's your link: %{link}"

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -11,6 +11,7 @@ module Passwordless
   mattr_accessor(:default_from_address) { "CHANGE_ME@example.com" }
   mattr_accessor(:token_generator) { UrlSafeBase64Generator.new }
   mattr_accessor(:restrict_token_reuse) { false }
+  mattr_accessor(:allow_token_resend) { false }
   mattr_accessor(:redirect_back_after_sign_in) { true }
   mattr_accessor(:mounted_as) { :configured_when_mounting_passwordless }
 

--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -121,8 +121,8 @@ module Passwordless
     # passwordless Model.
     # @param (see #authenticate_by_session)
     # @return [String] the redirect url that was just saved.
-    def save_passwordless_redirect_location!(authenticatable_class)
-      session[redirect_session_key(authenticatable_class)] = request.original_url
+    def save_passwordless_redirect_location!(authenticatable_class, location = request.original_url)
+      session[redirect_session_key(authenticatable_class)] = location
     end
 
     # Resets the redirect_location to root_path by deleting the redirect_url


### PR DESCRIPTION
When the config setting Passwordless.allow_token_resend = true a visit to /users/sign_in/TOKEN_URL for an expired or already claimed user will return a page with a button which can be used to resend an email with this token. Extra care is taken to record a query parameter `destination_path` into the current session, so opening the new email immediately from the same browser redirects you to the proper location.