### PR TITLE
User defined redirect_to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ Passwordless.redirect_back_after_sign_in = true # When enabled the user will be 
 Passwordless.expires_at = lambda { 1.year.from_now } # How long until a passwordless session expires.
 Passwordless.timeout_at = lambda { 1.hour.from_now } # How long until a magic link expires.
 
+# redirection session behavior
+Passwordless.redirect_to_response_options = {} # any allowed response_options for redirect_to can go in here
+
 # Default redirection paths
 Passwordless.success_redirect_path = '/' # When a user succeeds in logging in.
 Passwordless.failure_redirect_path = '/' # When a a login is failed for any reason.

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -47,13 +47,13 @@ module Passwordless
       BCrypt::Password.create(params[:token])
       sign_in(passwordless_session)
 
-      redirect_to(passwordless_success_redirect_path)
+      redirect_to(passwordless_success_redirect_path, Passwordless.redirect_to_response_options)
     rescue Errors::TokenAlreadyClaimedError
       flash[:error] = I18n.t(".passwordless.sessions.create.token_claimed")
-      redirect_to(passwordless_failure_redirect_path)
+      redirect_to(passwordless_failure_redirect_path, Passwordless.redirect_to_response_options)
     rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
-      redirect_to(passwordless_failure_redirect_path)
+      redirect_to(passwordless_failure_redirect_path, Passwordless.redirect_to_response_options)
     end
 
     # match '/sign_out', via: %i[get delete].

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -16,6 +16,7 @@ module Passwordless
 
   mattr_accessor(:expires_at) { lambda { 1.year.from_now } }
   mattr_accessor(:timeout_at) { lambda { 1.hour.from_now } }
+  mattr_accessor(:redirect_to_response_options) { {} }
   mattr_accessor(:success_redirect_path) { "/" }
   mattr_accessor(:failure_redirect_path) { "/" }
   mattr_accessor(:sign_out_redirect_path) { "/" }

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -197,6 +197,19 @@ module Passwordless
       assert_equal Passwordless.success_redirect_path, path
     end
 
+    test("signing in and redirecting with redirect_to options") do
+      Passwordless.redirect_to_response_options = { notice: 'hello!' }
+
+      user = User.create!(email: "a@a")
+      passwordless_session = create_session_for(user)
+      get "/users/sign_in/#{passwordless_session.token}"
+      follow_redirect!
+
+      assert_equal 'hello!', flash[:notice]
+      assert_equal 200, status
+      assert_equal Passwordless.success_redirect_path, path
+    end
+
     test("disabling redirecting back after sign in") do
       default = Passwordless.redirect_back_after_sign_in
       Passwordless.redirect_back_after_sign_in = false


### PR DESCRIPTION
This PR introduces a configuration settings that a host application can use to specify the `redirect_to` `response_options`.

```
# config/initializers/passwordless.rb

Passwordless.redirect_to_response_options = { allow_other_host: true, notice: 'Hello!' }
```

The setting is used in the `Passwordless::SessionsController#show` action