### PR TITLE
pass redirect_to options when signing out

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -44,16 +44,17 @@ module Passwordless
     # @see ControllerHelpers#save_passwordless_redirect_location!
     def show
       # Make it "slow" on purpose to make brute-force attacks more of a hassle
+      redirect_to_options = Passwordless.redirect_to_response_options.dup
       BCrypt::Password.create(params[:token])
       sign_in(passwordless_session)
 
-      redirect_to(passwordless_success_redirect_path, Passwordless.redirect_to_response_options)
+      redirect_to(passwordless_success_redirect_path, redirect_to_options)
     rescue Errors::TokenAlreadyClaimedError
       flash[:error] = I18n.t(".passwordless.sessions.create.token_claimed")
-      redirect_to(passwordless_failure_redirect_path, Passwordless.redirect_to_response_options)
+      redirect_to(passwordless_failure_redirect_path, redirect_to_options)
     rescue Errors::SessionTimedOutError
       flash[:error] = I18n.t(".passwordless.sessions.create.session_expired")
-      redirect_to(passwordless_failure_redirect_path, Passwordless.redirect_to_response_options)
+      redirect_to(passwordless_failure_redirect_path, redirect_to_options)
     end
 
     # match '/sign_out', via: %i[get delete].
@@ -61,7 +62,7 @@ module Passwordless
     # @see ControllerHelpers#sign_out
     def destroy
       sign_out(authenticatable_class)
-      redirect_to(passwordless_sign_out_redirect_path)
+      redirect_to(passwordless_sign_out_redirect_path, Passwordless.redirect_to_response_options.dup)
     end
 
     protected

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -252,6 +252,24 @@ module Passwordless
       assert session[Helpers.session_key(user.class)].blank?
     end
 
+    test("signing out with redirect_to options") do
+      Passwordless.redirect_to_response_options = { notice: 'bye!' }
+
+      user = User.create(email: "a@a")
+      passwordless_session = create_session_for(user)
+      get "/users/sign_in/#{passwordless_session.token}"
+      assert_not_nil session[Helpers.session_key(user.class)]
+
+      get "/users/sign_out"
+
+      follow_redirect!
+
+      assert_equal 'bye!', flash[:notice]
+      assert_equal 200, status
+      assert_equal "/", path
+      assert session[Helpers.session_key(user.class)].blank?
+    end
+
     test("trying to sign in with an timed out session") do
       user = User.create(email: "a@a")
       passwordless_session = create_session_for(user)


### PR DESCRIPTION
@mikker This is a followup to my earlier PR. 

First, I neglected to notice that the redirect_to options needed to be used on session destroy as well.

Second, in QA testing in my own app, I noticed some unusual behavior. This had to with the Rails `redirect_to` method manipulating the options hash that's passed into it. Since these options are passed by reference, the Passwordless configuration was being changed on the fly by Rails. I got around that by calling `.dup` on those options before passing them to `redirect_to`.