### PR TITLE
Add token as a second param to magic link email

### DIFF
--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -7,10 +7,13 @@ module Passwordless
 
     # Sends a magic link (secret token) email.
     # @param session [Session] A Passwordless Session
-    def magic_link(session)
+    # @param token [String] The token in plaintext. Falls back to `session.token` hoping it
+    # is still in memory (optional)
+    def magic_link(session, token = nil)
       @session = session
+      @token = token || session.token
 
-      @magic_link = send(:"#{session.authenticatable_type.downcase.pluralize}_token_sign_in_url", session.token)
+      @magic_link = send(:"#{session.authenticatable_type.downcase.pluralize}_token_sign_in_url", token)
 
       email_field = @session.authenticatable.class.passwordless_email_field
       mail(

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -61,16 +61,20 @@ module Passwordless
 
     private
 
+    def token_digest_available?(token_digest)
+      Session.available.where(token_digest: token_digest).none?
+    end
+
     def set_defaults
       self.expires_at ||= Passwordless.expires_at.call
       self.timeout_at ||= Passwordless.timeout_at.call
 
-      return if self.token || self.token_digest
+      return if self.token_digest
 
       self.token, self.token_digest = loop {
         token = Passwordless.token_generator.call(self)
         digest = Passwordless.digest(token)
-        break [token, digest] unless Session.find_by(token_digest: digest)
+        break [token, digest] if token_digest_available?(digest)
       }
     end
   end

--- a/lib/passwordless.rb
+++ b/lib/passwordless.rb
@@ -27,6 +27,8 @@ module Passwordless
   mattr_accessor(:sign_out_redirect_path) { "/" }
 
   mattr_accessor(:after_session_save) do
-    lambda { |session, _request| Mailer.magic_link(session).deliver_now }
+    lambda do |session, _request|
+      Mailer.magic_link(session, session.token).deliver_now
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,3 +30,7 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
   ActiveSupport::TestCase.fixtures(:all)
 end
+
+def Minitest.filter_backtrace(bt)
+  bt.select { |line| line !~ %r{/gems/} }
+end


### PR DESCRIPTION
- Add token as a second param to magic link email
- Move token availability checking to its own method for easier overriding
