### PR TITLE
Remove reference to deleted generator file

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,11 @@ end
 
 Override `passwordless`' bundled views by adding your own. You can manually copy the specific views that you need or copy them to your application with `rails generate passwordless:views`.
 
-`passwordless` has 2 action views and 1 mailer view:
+`passwordless` has 1 action view and 1 mailer view:
 
 ```sh
 # the form where the user inputs their email address
 app/views/passwordless/sessions/new.html.erb
-# shown after a user requests a magic link
-app/views/passwordless/sessions/create.html.erb
 # the mail with the magic link that gets sent
 app/views/passwordless/mailer/magic_link.text.erb
 ```

--- a/lib/generators/passwordless/views_generator.rb
+++ b/lib/generators/passwordless/views_generator.rb
@@ -8,7 +8,6 @@ module Passwordless
       def install
         copy_file("mailer/magic_link.text.erb", "app/views/passwordless/mailer/magic_link.text.erb")
         copy_file("sessions/new.html.erb", "app/views/passwordless/sessions/new.html.erb")
-        copy_file("sessions/create.html.erb", "app/views/passwordless/sessions/create.html.erb")
       end
     end
   end


### PR DESCRIPTION
After switching to the redirect strategy in https://github.com/mikker/passwordless/pull/120, there was a leftover reference to the deleted file in the view generator. This causes a non-critical error when running the views generator:

```
$ bin/rails g passwordless:views
      create  app/views/passwordless/mailer/magic_link.text.erb
      create  app/views/passwordless/sessions/new.html.erb
Could not find "sessions/create.html.erb" in any of your source paths. Your current source paths are: ...
```

Here's a quick fix to remove the reference to that file.