### PR TITLE
Return 200 on HEAD requests to not invalidate tokens

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -42,6 +42,10 @@ module Passwordless
     # @see ControllerHelpers#sign_in
     # @see ControllerHelpers#save_passwordless_redirect_location!
     def show
+      # Some email clients will visit links in emails to check if they are
+      # safe. We don't want to sign in the user in that case.
+      return head(:ok) if request.head?
+
       # Make it "slow" on purpose to make brute-force attacks more of a hassle
       redirect_to_options = Passwordless.redirect_to_response_options.dup
       BCrypt::Password.create(params[:token])

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -322,5 +322,17 @@ module Passwordless
 
       Passwordless.restrict_token_reuse = default
     end
+
+    test("responding to HEAD requests") do
+      user = User.create(email: "a@a")
+      passwordless_session = create_session_for(user)
+
+      token_path = "/users/sign_in/#{passwordless_session.token}"
+      head token_path
+
+      assert_equal 200, status
+      assert_equal token_path, path
+      assert_nil session[Helpers.session_key(user.class)]
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "simplecov"
-require "minitest/pride"
+require "minitest"
 
 SimpleCov.start do
   add_filter("test/dummy")


### PR DESCRIPTION
Some email clients send preliminary requests to links to check for safety. We don't want
that to invalidate tokens.
