### PR TITLE
Set a custom controller for `passwordless_for` routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,20 @@ Please note that, from a security standpoint, this is a **bad practice** because
 
 See [the bundled views](https://github.com/mikker/passwordless/tree/master/app/views/passwordless).
 
+### Using a custom controller
+
+``` ruby
+Rails.application.routes.draw do
+  passwordless_for :users, controller: 'sessions'
+
+  # other routes
+end
+
+class SessionsController < Passwordless::SessionsController
+end
+```
+
+
 ### Registering new users
 
 Because your `User` record is like any other record, you create one like you normally would. Passwordless provides a helper method to sign in the created user after it is saved – like so:

--- a/lib/passwordless/router_helpers.rb
+++ b/lib/passwordless/router_helpers.rb
@@ -8,6 +8,8 @@ module Passwordless
     #     passwordless_for :users
     #     # or with options ...
     #     passwordless_for :users, at: 'session_stuff', as: :user_session_things
+    #     # or with a custom controller ...
+    #     passwordless_for :users, controller: 'my_custom_controller'
     # @param resource [Symbol] the pluralized symbol of a Model (e.g - :users).
     # @param at [String] Optional - provide custom path for the passwordless
     #   engine to get mounted at (using the above example your URLs end
@@ -16,15 +18,23 @@ module Passwordless
     #   helpers (using the above example in a view:
     #   <%= link_to 'Sign in', user_session_things.sign_in_path %>).
     #   (Default: resource.to_s)
-    def passwordless_for(resource, at: :na, as: :na)
+    # @param controller [String] Optional - provide a custom controller for
+    #  sessions to use (using the above example the controller called would be MyCustomController
+    #  (Default: 'passwordless/sessions')
+    def passwordless_for(resource, at: :na, as: :na, controller: 'passwordless/sessions', )
       at == :na && at = "/#{resource.to_s}"
-      as == :na && as = "#{resource.to_s}_"
+      as == :na && as = resource.to_s
 
-      scope(defaults: {authenticatable: resource.to_s.singularize, resource: resource}) do
-        get("#{at}/sign_in", to: "passwordless/sessions#new", as: :"#{as}sign_in")
-        post("#{at}/sign_in", to: "passwordless/sessions#create")
-        get("#{at}/sign_in/:token", to: "passwordless/sessions#show", as: :"#{as}token_sign_in")
-        match("#{at}/sign_out", to: "passwordless/sessions#destroy", via: %i[get delete], as: :"#{as}sign_out")
+      defaults = {
+        authenticatable: resource.to_s.singularize,
+        resource: resource,
+      }
+
+      scope(defaults: defaults) do
+        get("#{at}/sign_in", to: "#{controller}#new", as: :"#{as}_sign_in")
+        post("#{at}/sign_in", to: "#{controller}#create")
+        get("#{at}/sign_in/:token", to: "#{controller}#show", as: :"#{as}_token_sign_in")
+        match("#{at}/sign_out", to: "#{controller}#destroy", via: %i[get delete], as: :"#{as}_sign_out")
       end
     end
   end

--- a/lib/passwordless/router_helpers.rb
+++ b/lib/passwordless/router_helpers.rb
@@ -21,7 +21,7 @@ module Passwordless
     # @param controller [String] Optional - provide a custom controller for
     #  sessions to use (using the above example the controller called would be MyCustomController
     #  (Default: 'passwordless/sessions')
-    def passwordless_for(resource, at: :na, as: :na, controller: 'passwordless/sessions', )
+    def passwordless_for(resource, at: :na, as: :na, controller: 'passwordless/sessions')
       at == :na && at = "/#{resource.to_s}"
       as == :na && as = resource.to_s
 

--- a/test/dummy/app/controllers/admin/sessions_controller.rb
+++ b/test/dummy/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,5 @@
+
+class Admin
+  class SessionsController < Passwordless::SessionsController
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   passwordless_for(:users)
-  passwordless_for(:admins)
+  passwordless_for(:admins, controller: 'admin/sessions')
 
   resources(:users)
   resources(:registrations, only: %i[new create])

--- a/test/passwordless_for_test.rb
+++ b/test/passwordless_for_test.rb
@@ -54,7 +54,7 @@ module Passwordless
     test("map sign in for admin") do
       assert_recognizes(
         {
-          controller: "passwordless/sessions",
+          controller: "admin/sessions",
           action: "new",
           authenticatable: "admin",
           resource: "admins"
@@ -65,7 +65,7 @@ module Passwordless
 
       assert_recognizes(
         {
-          controller: "passwordless/sessions",
+          controller: "admin/sessions",
           action: "create",
           authenticatable: "admin",
           resource: "admins"
@@ -76,7 +76,7 @@ module Passwordless
 
       assert_recognizes(
         {
-          controller: "passwordless/sessions",
+          controller: "admin/sessions",
           action: "show",
           authenticatable: "admin",
           resource: "admins",
@@ -88,7 +88,7 @@ module Passwordless
 
       assert_recognizes(
         {
-          controller: "passwordless/sessions",
+          controller: "admin/sessions",
           action: "destroy",
           authenticatable: "admin",
           resource: "admins"


### PR DESCRIPTION
Closer to using multiple models in the same project. E.g providing Devise like support for ActiveAdmin but with Passwordless

``` ruby
module Admin
  class SessionsController < Passwordless::SessionsController
    layout 'admin'
  end
end
```

``` ruby
passwordless_for :users
passwordless_for :admin_users, controller: 'admin/sessions'
```
