### PR TITLE
Use `tableize` instead of `downcase`

### DIFF
--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -13,7 +13,7 @@ module Passwordless
       @session = session
       @token = token || session.token
 
-      @magic_link = send(:"#{session.authenticatable_type.downcase.pluralize}_token_sign_in_url", token)
+      @magic_link = send(:"#{session.authenticatable_type.tableize}_token_sign_in_url", token)
 
       email_field = @session.authenticatable.class.passwordless_email_field
       mail(


### PR DESCRIPTION
In the case of using Passwordless with ActiveAdmin I came across this use. `AdminUser` will be downcased to `adminuser` and then pluralized to `adminusers`. Instead it should be `admin_users`. This is that `tableize` does and in a single method call. So no need to pluralize afterwards