### PR TITLE
Add a Passwordless::ControllerHelpers#sign_in_authenticatable method

### DIFF
--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -31,7 +31,7 @@ module Passwordless
     end
 
     # Signs in an authenticatable 
-    # @param authenticatable [ActiveRecord::Base] An an instance of a user Model
+    # @param authenticatable [ActiveRecord::Base] an instance of the user Model
     # @return [ActiveRecord::Base|boolean] a Passwordless::Session for the Model
     def sign_in_authenticatable(authenticatable)
       session = build_passwordless_session(authenticatable)

--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -30,6 +30,14 @@ module Passwordless
       find_passwordless_session_for(authenticatable_class).authenticatable
     end
 
+    # Signs in an authenticatable 
+    # @param authenticatable [ActiveRecord::Base] An an instance of a user Model
+    # @return [ActiveRecord::Base|boolean] a Passwordless::Session for the Model
+    def sign_in_authenticatable(authenticatable)
+      session = build_passwordless_session(authenticatable)
+      session.save && sign_in(session)
+    end
+
     # Signs in session
     # @param authenticatable [Passwordless::Session] Instance of {Passwordless::Session}
     # to sign in


### PR DESCRIPTION
The old version of Passwordless allowed me to sign in a user with a simple `sign_in user` call. The new version requires me to pass a session object instead, so I've added a simple `sign_in_authenticatable user` method to complement it. Hope you like it. I use this when I'm auth'ing via a Google login instead of a sign-in link via email.