### PR TITLE
CI: Configure dependabot to update GitHub Actions, too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
 - package-ecosystem: bundler
   directory: "/"
   schedule:


### PR DESCRIPTION
This PR adds github-actions to "auto-PR updates".