### PR TITLE
Use UUIDs as indentifiers for sessions in public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ Sessions are now referenced publicly by a random UUID instead of their primary k
 
 This needs a manual database migration like so:
 
-...TODO
+```ruby
+class AddIndentifierToPasswordlessSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column(:passwordless_sessions, :identifier, :string)
+    add_index(:passwordless_sessions, :identifier, unique: true)
+  end
+end
+```
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Unreleased
 
+### Changed
+
+Sessions are now referenced publicly by a random UUID instead of their primary key.
+
+This needs a manual database migration like so:
+
+...TODO
+
 ### Added
 
 - Add default flash notice for sign out (#178)

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -37,7 +37,7 @@ module Passwordless
         end
 
         redirect_to(
-          url_for(id: @session.id, action: "show"),
+          url_for(id: @session.identifier, action: "show"),
           flash: {notice: I18n.t("passwordless.sessions.create.email_sent")}
         )
       else
@@ -54,7 +54,7 @@ module Passwordless
     #   Shows the form for confirming a Session record.
     #   renders sessions/show.html.erb.
     def show
-      @session = find_session
+      @session = passwordless_session
     end
 
     # patch "/:resource/sign_in/:id"
@@ -66,7 +66,7 @@ module Passwordless
     # @see ControllerHelpers#sign_in
     # @see ControllerHelpers#save_passwordless_redirect_location!
     def update
-      @session = find_session
+      @session = passwordless_session
 
       artificially_slow_down_brute_force_attacks(passwordless_session_params[:token])
 
@@ -86,7 +86,7 @@ module Passwordless
       # safe. We don't want to sign in the user in that case.
       return head(:ok) if request.head?
 
-      @session = find_session
+      @session = passwordless_session
 
       artificially_slow_down_brute_force_attacks(params[:token])
 
@@ -166,10 +166,6 @@ module Passwordless
       authenticatable_type.constantize
     end
 
-    def find_session
-      Session.find_by!(id: params[:id], authenticatable_type: authenticatable_type)
-    end
-
     def find_authenticatable
       email = passwordless_session_params[email_field].downcase.strip
 
@@ -201,7 +197,7 @@ module Passwordless
 
     def passwordless_session
       @passwordless_session ||= Session.find_by!(
-        id: params[:id],
+        identifier: params[:id],
         authenticatable_type: authenticatable_type
       )
     end

--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -16,7 +16,7 @@ module Passwordless
         {
           controller: "passwordless/sessions",
           action: "confirm",
-          id: session.id,
+          id: session.identifier,
           token: token,
           authenticatable: "user",
           resource: "users"

--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -61,6 +61,10 @@ module Passwordless
       !expired?
     end
 
+    def to_param
+      identifier
+    end
+
     private
 
     def token_digest_available?(token_digest)
@@ -68,6 +72,7 @@ module Passwordless
     end
 
     def set_defaults
+      self.identifier = SecureRandom.uuid
       self.expires_at ||= Passwordless.config.expires_at.call
       self.timeout_at ||= Passwordless.config.timeout_at.call
 

--- a/db/migrate/20171104221735_create_passwordless_sessions.rb
+++ b/db/migrate/20171104221735_create_passwordless_sessions.rb
@@ -13,6 +13,7 @@ class CreatePasswordlessSessions < ActiveRecord::Migration[5.1]
       t.datetime(:expires_at, null: false)
       t.datetime(:claimed_at)
       t.string(:token_digest, null: false)
+      t.string(:identifier, null: false, index: {unique: true}, length: 36)
 
       t.timestamps
     end

--- a/docs/upgrading_to_1_0.md
+++ b/docs/upgrading_to_1_0.md
@@ -20,7 +20,7 @@ $ bin/rails g migration UpgradePassswordless
 ```
 
 ```ruby
-class UpgradePassswordless < ActiveRecord::Migration[7.0]
+class UpgradePasswordless < ActiveRecord::Migration[7.0]
   def change
     # Encrypted tokens
     add_column(:passwordless_sessions, :token_digest, :string)

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -28,7 +28,7 @@ module Passwordless
       assert_equal 1, ActionMailer::Base.deliveries.size
 
       follow_redirect!
-      assert_equal "/users/sign_in/#{Session.last!.id}", path
+      assert_equal "/users/sign_in/#{Session.last!.identifier}", path
     end
 
     test("POST /:passwordless_for/sign_in -> SUCCESS / malformed email") do
@@ -40,7 +40,7 @@ module Passwordless
       assert_equal 1, ActionMailer::Base.deliveries.size
 
       follow_redirect!
-      assert_equal "/users/sign_in/#{Session.last!.id}", path
+      assert_equal "/users/sign_in/#{Session.last!.identifier}", path
     end
 
     test("POST /:passwordless_for/sign_in -> SUCCESS / custom delivery method") do
@@ -111,7 +111,7 @@ module Passwordless
     test("GET /:passwordless_for/sign_in/:id") do
       passwordless_session = create_pwless_session
 
-      get("/users/sign_in/#{passwordless_session.id}")
+      get("/users/sign_in/#{passwordless_session.identifier}")
 
       assert_equal 200, status
       assert_equal "/users/sign_in/#{passwordless_session.to_param}", path
@@ -121,7 +121,7 @@ module Passwordless
     test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS") do
       passwordless_session = create_pwless_session(token: "hi")
 
-      patch("/users/sign_in/#{passwordless_session.id}", params: {passwordless: {token: "hi"}})
+      patch("/users/sign_in/#{passwordless_session.identifier}", params: {passwordless: {token: "hi"}})
 
       assert_equal 303, status
 
@@ -135,7 +135,7 @@ module Passwordless
     test("PATCH /:passwordless_for/sign_in/:id -> ERROR") do
       passwordless_session = create_pwless_session(token: "hi")
 
-      patch("/users/sign_in/#{passwordless_session.id}", params: {passwordless: {token: "no"}})
+      patch("/users/sign_in/#{passwordless_session.identifier}", params: {passwordless: {token: "no"}})
 
       assert_equal 403, status
       assert_equal "/users/sign_in/#{passwordless_session.to_param}", path
@@ -150,7 +150,7 @@ module Passwordless
 
       with_config(restrict_token_reuse: true) do
         patch(
-          "/users/sign_in/#{passwordless_session.id}",
+          "/users/sign_in/#{passwordless_session.identifier}",
           params: {passwordless: {token: "hi"}}
         )
       end
@@ -170,7 +170,7 @@ module Passwordless
       passwordless_session.update!(timeout_at: Time.current - 1.day)
 
       patch(
-        "/users/sign_in/#{passwordless_session.id}",
+        "/users/sign_in/#{passwordless_session.identifier}",
         params: {passwordless: {token: "hi"}}
       )
 
@@ -188,7 +188,7 @@ module Passwordless
       user = User.create(email: "a@a")
       passwordless_session = create_pwless_session(authenticatable: user, token: "hi")
 
-      get "/users/sign_in/#{passwordless_session.id}/#{passwordless_session.token}"
+      get "/users/sign_in/#{passwordless_session.identifier}/#{passwordless_session.token}"
       assert_not_nil pwless_session(User)
 
       get "/users/sign_out"

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :internal
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -18,9 +18,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_06_21_085550) do
     t.datetime "expires_at", precision: nil, null: false
     t.datetime "claimed_at", precision: nil
     t.string "token_digest", null: false
+    t.string "identifier", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"
+    t.index ["identifier"], name: "index_passwordless_sessions_on_identifier", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/fixtures/passwordless/sessions.yml
+++ b/test/fixtures/passwordless/sessions.yml
@@ -1,16 +1,19 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  identifier: 381a283e-4e64-4989-8b10-d5279bb7f338
   timeout_at: 2017-11-04 23:17:35
   expires_at: 2017-11-04 23:17:35
   token_digest: MyString
 
 two:
+  identifier: cb756ce8-62a0-4ac1-9cb2-7abce7eddf80
   timeout_at: 2017-11-04 23:17:35
   expires_at: 2017-11-04 23:17:35
   token_digest: MyString
 
 john:
+  identifier: 3d14ed2c-4eaa-4894-82fb-e2e6f92223e6
   timeout_at: 2017-11-04 23:17:35
   expires_at: 2017-11-04 23:17:35
   token_digest: 3veDCdFw4VedgZtZZkCJ7um7rsc2bFNCZGB51Iih024

--- a/test/integration/authentication_flow_test.rb
+++ b/test/integration/authentication_flow_test.rb
@@ -28,7 +28,7 @@ class AuthenticationFlowTest < ActionDispatch::SystemTestCase
 
     email = ActionMailer::Base.deliveries.last
     assert_equal alice.email, email.to.first
-    token = email.body.match(%r{/sign_in/\d+/([\w\-_]+)})[1]
+    token = email.body.match(%r{http://.*/sign_in/[A-Za-z0-9\-]+/(\w+)})[1]
 
     fill_in "passwordless[token]", with: token
     click_button "Confirm"
@@ -52,7 +52,7 @@ class AuthenticationFlowTest < ActionDispatch::SystemTestCase
 
     email = ActionMailer::Base.deliveries.last
     assert_equal alice.email, email.to.first
-    magic_link = email.body.to_s.scan(%r{http://.*/sign_in/\d+/\w+}).at(0)
+    magic_link = email.body.to_s.scan(%r{http://.*/sign_in/[a-z0-9\-]+/\w+}).at(0)
 
     visit magic_link
 

--- a/test/mailers/passwordless/mailer_test.rb
+++ b/test/mailers/passwordless/mailer_test.rb
@@ -11,6 +11,6 @@ class Passwordless::MailerTest < ActionMailer::TestCase
 
     assert_match "Signing in ✨", email.subject
     assert_match /sign in: hello\n/, email.body.to_s
-    assert_match %r{/sign_in/#{session.id}/hello}, email.body.to_s
+    assert_match %r{/sign_in/#{session.identifier}/hello}, email.body.to_s
   end
 end


### PR DESCRIPTION
As per discussion with @yshmarov in #169, a proposal to use UUIDs as Session identifiers in public.

It might be a bit more space and cpu optimized to use UUIDs as the primary keys directly but AFAIK that involves having to turn on a Postgres plugin `pgcrypto` [guides ref](https://guides.rubyonrails.org/v5.0/active_record_postgresql.html#uuid).

I feel like that puts unnecessary hassle on the user's end re: using DBs you don't control, etc. I'm also hesitant to add another required migration upgrade.

This way we can do the switch with only a _vaguely_ breaking change (lol, if that's a thing)

@yshmarov what do you think?