### PR TITLE
Add default flash notice on SessionsController#destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+### Added
+
+- Add default flash notice for sign out (#178)
+
 ## 1.0.1
 
 ### Fixed

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -99,11 +99,11 @@ module Passwordless
     def destroy
       sign_out(authenticatable_class)
 
-      redirect_to_response_options = {
-        notice: I18n.t("passwordless.sessions.destroy.signed_out")
-      }.merge(redirect_to_options)
-
-      redirect_to(passwordless_sign_out_redirect_path, redirect_to_response_options)
+      redirect_to(
+        passwordless_sign_out_redirect_path,
+        notice: I18n.t("passwordless.sessions.destroy.signed_out"),
+        **redirect_to_options
+      )
     end
 
     protected

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -98,7 +98,12 @@ module Passwordless
     # @see ControllerHelpers#sign_out
     def destroy
       sign_out(authenticatable_class)
-      redirect_to(passwordless_sign_out_redirect_path, Passwordless.config.redirect_to_response_options.dup)
+
+      redirect_to_response_options = {
+        notice: I18n.t("passwordless.sessions.destroy.signed_out")
+      }.merge(redirect_to_options)
+
+      redirect_to(passwordless_sign_out_redirect_path, redirect_to_response_options)
     end
 
     protected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
         invalid_token: "Token is invalid"
         session_expired: "Your session has expired, please sign in again."
         token_claimed: "This link has already been used, try requesting the link again"
+      destroy:
+        signed_out: "Signed out successfully"
     mailer:
       sign_in:
         subject: "Signing in ✨"

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -196,29 +196,15 @@ module Passwordless
 
       assert_equal 200, status
       assert_equal "/", path
-      assert_match I18n.t("passwordless.sessions.destroy.signed_out"), flash[:notice]
+      assert_match "Signed out successfully", flash[:notice]
       assert pwless_session(User).blank?
     end
 
     test("DELETE /:passwordless_for/sign_out :: When response options are configured ") do
-      Passwordless.configure do |config|
-        config.redirect_to_response_options = {
-          notice: "my custom notice"
-        }
+      with_config(redirect_to_response_options: {notice: "my custom notice"}) do
+        get "/users/sign_out"
+        assert_match "my custom notice", flash[:notice]
       end
-
-      user = User.create(email: "a@a")
-      passwordless_session = create_pwless_session(authenticatable: user, token: "hi")
-
-      get "/users/sign_in/#{passwordless_session.id}/#{passwordless_session.token}"
-      assert_not_nil pwless_session(User)
-
-      get "/users/sign_out"
-      follow_redirect!
-
-      assert_equal 200, status
-      assert pwless_session(User).blank?
-      assert_match "my custom notice", flash[:notice]
     end
 
     class Helpers


### PR DESCRIPTION
## What 

This commit adds a default flash notice to destroy action while keeping the flexibility to customize redirect options via config.

## Why

When creating a session in case of success, a flash notice is displayed, while when destroying a session, there was no flash notice displayed in case of success.

Also, having a successful flash message for destroying a session makes the system tests in the apps using this gem a bit easier to check if the logout happened successfully.