### PR TITLE
Fix passwordless_sign_in bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fixed a bug in `passwordless_sign_in` (#179)
+
 ## 1.1.0
 
 ### Changed

--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -17,7 +17,7 @@ module Passwordless
           controller: "passwordless/sessions",
           action: "confirm",
           id: session.identifier,
-          token: token,
+          token: @token,
           authenticatable: "user",
           resource: "users"
         }

--- a/app/views/passwordless/sessions/new.html.erb
+++ b/app/views/passwordless/sessions/new.html.erb
@@ -3,9 +3,10 @@
   <%= f.label email_field_name,
           t("passwordless.sessions.new.email.label"),
           for: "passwordless_#{email_field}" %>
-  <%= text_field_tag email_field_name,
+  <%= email_field_tag email_field_name,
   params.fetch(email_field_name, nil),
   required: true,
+  autofocus: true,
   placeholder: t("passwordless.sessions.new.email.placeholder") %>
   <%= f.submit t("passwordless.sessions.new.submit") %>
 <% end %>

--- a/docs/upgrading_to_1_0.md
+++ b/docs/upgrading_to_1_0.md
@@ -26,6 +26,9 @@ class UpgradePasswordless < ActiveRecord::Migration[7.0]
     add_column(:passwordless_sessions, :token_digest, :string)
     add_index(:passwordless_sessions, :token_digest)
     remove_column(:passwordless_sessions, :token, :string, null: false)
+    # UUID
+    add_column(:passwordless_sessions, :identifier, :string)
+    add_index(:passwordless_sessions, :identifier, unique: true)
 
     # Remove PII
     remove_column(:passwordless_sessions, :user_agent, :string, null: false)

--- a/lib/passwordless/test_helpers.rb
+++ b/lib/passwordless/test_helpers.rb
@@ -22,7 +22,7 @@ module Passwordless
           {
             controller: "passwordless/sessions",
             action: "confirm",
-            id: session.id,
+            id: session.to_param,
             token: session.token,
             authenticatable: cls.model_name.singular,
             resource: cls.model_name.to_s.tableize

--- a/test/mailers/passwordless/mailer_test.rb
+++ b/test/mailers/passwordless/mailer_test.rb
@@ -12,5 +12,9 @@ class Passwordless::MailerTest < ActionMailer::TestCase
     assert_match "Signing in ✨", email.subject
     assert_match /sign in: hello\n/, email.body.to_s
     assert_match %r{/sign_in/#{session.identifier}/hello}, email.body.to_s
+
+    session = Passwordless::Session.create!(authenticatable: user)
+    email = Passwordless::Mailer.sign_in(session)
+    assert_equal [user.email], email.to
   end
 end

--- a/test/passwordless/test_helpers_test.rb
+++ b/test/passwordless/test_helpers_test.rb
@@ -46,7 +46,7 @@ module Passwordless
       assert 1, Session.count
       assert alice, Session.last!.authenticatable
       assert_match(
-        %r{^http://.*/users/sign_in/[a-z0-9-]+/[A-Z0-9]+}i,
+        %r{^http://.*/users/sign_in/[a-z0-9-]+/[a-z0-9]+}i,
         controller.actions.first.last.first
       )
 

--- a/test/passwordless/test_helpers_test.rb
+++ b/test/passwordless/test_helpers_test.rb
@@ -46,7 +46,7 @@ module Passwordless
       assert 1, Session.count
       assert alice, Session.last!.authenticatable
       assert_match(
-        %r{^http://.*/users/sign_in/[a-z0-9]+/[a-z0-9]+}i,
+        %r{^http://.*/users/sign_in/[a-z0-9-]+/[A-Z0-9]+}i,
         controller.actions.first.last.first
       )
 


### PR DESCRIPTION
failing tests at `passwordless_sign_in(user)` led me on such a trail....

- @token was not being set correctly
- we were using `id` instead of the identifier
- minor improvements in the html template (`email_field_tag` provides basic validations)

<img width="1242" alt="bug" src="https://github.com/mikker/passwordless/assets/13472945/f0550440-f929-4255-a903-398f984089c8">
