### PR TITLE
Add paranoid flag to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Passwordless.configure do |config|
   config.parent_mailer = "ActionMailer::Base"
   config.restrict_token_reuse = false # Can a token/link be used multiple times?
   config.token_generator = Passwordless::ShortTokenGenerator.new # Used to generate magic link tokens.
+  config.paranoid = false # Set to `true` to prevent unintentional email existence leaks in the database.
 
   config.expires_at = lambda { 1.year.from_now } # How long until a signed in session expires.
   config.timeout_at = lambda { 10.minutes.from_now } # How long until a token/magic link times out.

--- a/lib/passwordless/config.rb
+++ b/lib/passwordless/config.rb
@@ -31,6 +31,7 @@ module Passwordless
     option :parent_mailer, default: "ActionMailer::Base"
     option :restrict_token_reuse, default: true
     option :token_generator, default: ShortTokenGenerator.new
+    option :paranoid, default: false
 
     option :expires_at, default: lambda { 1.year.from_now }
     option :timeout_at, default: lambda { 10.minutes.from_now }


### PR DESCRIPTION
Hi, this is my attempt to tackle the paranoid option to hide user existence when requesting token [on Sep 21](https://github.com/mikker/passwordless/issues/131#event-10434257219)
When the paranoid flag is enabled, and a user tries to sign in with a non existing email:
- The same behavior will be shown to the user. 
- No email will be sent to non existing emails/user.
- A session will still be created for non existing emails/user. I am not sure how big of a deal it is, so I left it like that for now.