### PR TITLE
Allow from address to fall back to parent mailer

### DIFF
--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -3,7 +3,7 @@
 module Passwordless
   # The mailer responsible for sending Passwordless' mails.
   class Mailer < Passwordless.config.parent_mailer.constantize
-    default from: Passwordless.config.default_from_address
+    default Passwordless.config.mailer_defaults
 
     # Sends a token and a magic link
     #

--- a/lib/passwordless/config.rb
+++ b/lib/passwordless/config.rb
@@ -50,6 +50,12 @@ module Passwordless
     def initialize
       set_defaults!
     end
+
+    def mailer_defaults
+      # Compacting the Hash removes all keys with nil values, allowing to let
+      # the `from` address fall back to the parent mailer's default.
+      { from: default_from_address }.compact
+    end
   end
 
   module Configurable
@@ -67,5 +73,4 @@ module Passwordless
       @config = Configuration.new
     end
   end
-
 end

--- a/test/mailers/passwordless/mailer_test.rb
+++ b/test/mailers/passwordless/mailer_test.rb
@@ -35,4 +35,14 @@ class Passwordless::MailerTest < ActionMailer::TestCase
     assert_match /sign in: hello\n/, email.body.to_s
     assert_match %r{/admins/sign_in/#{session.identifier}/hello}, email.body.to_s
   end
+
+  test("without default_from_address falls back to parent_mailer") do
+    WithConfig.with_config({default_from_address: nil, parent_mailer: "ApplicationMailer"}) do
+      email = Passwordless::Mailer.sign_in(
+        Passwordless::Session.create!(authenticatable: users(:alice), token: "hello")
+      )
+
+      assert_equal ["from@example.com"], email.from
+    end
+  end
 end


### PR DESCRIPTION
I'm in a situation where I want the parent mailer class to set the `from` address. 

The use case is that based on the `I18n.locale` we set a different from address/domain.

Right now it's not possible to do this, as even with `nil` for `default_from_address` it will not fall back to the parent (the mailer will fail: ArgumentError (SMTP From address may not be blank)). That basically means only one, fixed from address is supported.

I've come up with a small PR that makes that work by not setting the default value if it's nil.

Curious to hear what you think, I'm not entirely sure about:

* Is the config the right place for that `mailer_defaults` method? Feel like it could also live in the `Passwordless::Mailer` class.
* Does it even need it's own method like this, since there's only one default being set right now. It's easily extendable in the future like this, though.
* ~~I've had some issues with getting all tests to run, not sure if this is correct now. Since we need to change the config just for this test, I _think_ setting it like this and resetting at the end is the best way to do it.~~ edit: found the `WithConfig.with_config` helper that solves my problem 😊
* Probably needs some documentation.

Happy to take it in the direction you want with some pointers 😁
