### PR TITLE
Pass default_url_options from mailer

### DIFF
--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -17,7 +17,8 @@ module Passwordless
         session,
         action: "confirm",
         id: session.to_param,
-        token: @token
+        token: @token,
+        **default_url_options
       )
 
       email_field = session.authenticatable.class.passwordless_email_field

--- a/test/dummy/app/mailers/application_mailer.rb
+++ b/test/dummy/app/mailers/application_mailer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "from@example.org"
   layout "mailer"
 
   def default_url_options
-    { host: "example.com" }
+    { host: "www.example.org" }
   end
 end

--- a/test/dummy/app/mailers/application_mailer.rb
+++ b/test/dummy/app/mailers/application_mailer.rb
@@ -3,4 +3,8 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"
+
+  def default_url_options
+    { host: "example.com" }
+  end
 end

--- a/test/mailers/passwordless/mailer_test.rb
+++ b/test/mailers/passwordless/mailer_test.rb
@@ -40,15 +40,15 @@ class Passwordless::MailerTest < ActionMailer::TestCase
     session = Passwordless::Session.create!(authenticatable: users(:alice), token: "hello")
     email = Passwordless::Mailer.sign_in(session, "hello")
 
-    assert_match %r{localhost:3000/users/sign_in/#{session.identifier}/hello}, email.body.to_s
+    assert_match %r{www.example.com/users/sign_in/#{session.identifier}/hello}, email.body.to_s
   end
 
   test("uses default_url_options from mailer") do
-    WithConfig.with_config({parent_mailer: "ApplicationMailer"}) do
+    with_config({parent_mailer: "ApplicationMailer"}) do
       session = Passwordless::Session.create!(authenticatable: users(:alice), token: "hello")
       email = Passwordless::Mailer.sign_in(session, "hello")
 
-      assert_match %r{example.com/users/sign_in/#{session.identifier}/hello}, email.body.to_s
+      assert_match %r{www.example.org/users/sign_in/#{session.identifier}/hello}, email.body.to_s
     end
   end
 end

--- a/test/mailers/passwordless/mailer_test.rb
+++ b/test/mailers/passwordless/mailer_test.rb
@@ -35,4 +35,20 @@ class Passwordless::MailerTest < ActionMailer::TestCase
     assert_match /sign in: hello\n/, email.body.to_s
     assert_match %r{/admins/sign_in/#{session.identifier}/hello}, email.body.to_s
   end
+
+  test("uses default_url_options from config.action_mailer") do
+    session = Passwordless::Session.create!(authenticatable: users(:alice), token: "hello")
+    email = Passwordless::Mailer.sign_in(session, "hello")
+
+    assert_match %r{localhost:3000/users/sign_in/#{session.identifier}/hello}, email.body.to_s
+  end
+
+  test("uses default_url_options from mailer") do
+    WithConfig.with_config({parent_mailer: "ApplicationMailer"}) do
+      session = Passwordless::Session.create!(authenticatable: users(:alice), token: "hello")
+      email = Passwordless::Mailer.sign_in(session, "hello")
+
+      assert_match %r{example.com/users/sign_in/#{session.identifier}/hello}, email.body.to_s
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,7 +56,7 @@ module WithConfig
     # We need to reload the application, because the config can set a different
     # parent_mailer class, which means `Passwordless::Mailer` needs to be
     # reloaded. Simply reloading the whole application seems to be the easiest.
-    Rails.application.reloader.reload!
+    Rails.application.reloader.reload! if options.has_key?(:parent_mailer)
 
     yield
   ensure

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,6 +61,8 @@ module WithConfig
     yield
   ensure
     Passwordless.reset_config!
+    # Reload the application again, because we reset the config.
+    Rails.application.reloader.reload! if options.has_key?(:parent_mailer)
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,6 +53,11 @@ module WithConfig
       end
     end
 
+    # We need to reload the application, because the config can set a different
+    # parent_mailer class, which means `Passwordless::Mailer` needs to be
+    # reloaded. Simply reloading the whole application seems to be the easiest.
+    Rails.application.reloader.reload!
+
     yield
   ensure
     Passwordless.reset_config!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,23 +53,16 @@ module WithConfig
       end
     end
 
-    # We need to reload the application, because the config can set a different
-    # parent class for the mailer, which means `Passwordless::Mailer` needs to be
-    # reloaded.
-    reload_mailer! if options.has_key?(:parent_mailer)
-
     yield
   ensure
     Passwordless.reset_config!
-
-    # Reload the application again, because we reset the config.
-    reload_mailer! if options.has_key?(:parent_mailer)
   end
 
-  private
-
-  # Reloads the Mailer by removing its constant and reloading the mailer file manually.
-  # This is quite a hack, but it seems to work.
+  # Reloads the Mailer by removing its constant and reloading the mailer file
+  # manually. This is quite a hack, but it seems to work.
+  # 
+  # This can be used when you change the`parent_mailer` config option and need
+  # it load a different parent class.
   def reload_mailer!
     Passwordless.send(:remove_const, :Mailer)
     load File.expand_path("../../app/mailers/passwordless/mailer.rb", __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,15 +54,25 @@ module WithConfig
     end
 
     # We need to reload the application, because the config can set a different
-    # parent_mailer class, which means `Passwordless::Mailer` needs to be
-    # reloaded. Simply reloading the whole application seems to be the easiest.
-    Rails.application.reloader.reload! if options.has_key?(:parent_mailer)
+    # parent class for the mailer, which means `Passwordless::Mailer` needs to be
+    # reloaded.
+    reload_mailer! if options.has_key?(:parent_mailer)
 
     yield
   ensure
     Passwordless.reset_config!
+
     # Reload the application again, because we reset the config.
-    Rails.application.reloader.reload! if options.has_key?(:parent_mailer)
+    reload_mailer! if options.has_key?(:parent_mailer)
+  end
+
+  private
+
+  # Reloads the Mailer by removing its constant and reloading the mailer file manually.
+  # This is quite a hack, but it seems to work.
+  def reload_mailer!
+    Passwordless.send(:remove_const, :Mailer)
+    load File.expand_path("../../app/mailers/passwordless/mailer.rb", __FILE__)
   end
 end
 


### PR DESCRIPTION
This is a bit related to #187, with the same behavior where we set the hostname dynamically based on locale.

With the introduction of the context in 1.1.0 (I think?) (PR: #180). the url helpers are no longer using the `default_url_options` from the mailer (either via `config.action_mailer.default_url_options` or when overriding them in a mailer themselves via a `default_url_options` method).

This PR fixes that by passing them as arguments to the `url_for` method from the context.

This probably also means you no longer necessarily need to to set a default host for the routes as well, as mentioned here in the docs:

https://github.com/mikker/passwordless/blob/cd0e0ed7cdba745dcae92e84d800122b8d3368b6/README.md?plain=1#L148-L155

I also added a reload when using `WithConfig`, as the parent class for the mailer is set from the config and that can change based on usage of the helper. This probably also needs to be included in #187.

Let me know what you think!
