### PR TITLE
Update README.md to include CreateUsers migration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ class User < ApplicationRecord
 end
 ```
 
+You might want to update the generated migration file to include db-level constraints similar to the model validation above:
+
+```ruby
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+
+      t.index 'LOWER(email)', unique: true, name: 'index_users_on_lowercase_email'
+
+      t.timestamps
+    end
+  end
+end
+```
+
+
 Finally, mount the engine in your routes:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -25,43 +25,21 @@ See [Upgrading to Passwordless 1.0](docs/upgrading_to_1_0.md) for more details.
 
 ## Usage
 
-Passwordless creates a single model called `Passwordless::Session`. It doesn't come with its own `User` model, it expects you to create one:
+Passwordless creates a single model called `Passwordless::Session`, so it doesn't come with its own user model. Instead, it expects you to provide one, with an email field in place. If you don't yet have a user model, check out the wiki on [creating the user model](https://github.com/mikker/passwordless/wiki/Creating-the-user-model).
 
-```sh
-$ bin/rails generate model User email
-```
-
-Then specify which field on your `User` record is the email field with:
+Enable Passwordless on your user model by pointing it to the email field:
 
 ```ruby
 class User < ApplicationRecord
-  validates :email,
-            presence: true,
-            uniqueness: { case_sensitive: false },
-            format: { with: URI::MailTo::EMAIL_REGEXP }
-
-  passwordless_with :email # <-- here!
+  # your other code..
+  
+  passwordless_with :email # <-- here! this needs to be a column in `users` table
+  
+  # more of your code..
 end
 ```
 
-You might want to update the generated migration file to include db-level constraints similar to the model validation above:
-
-```ruby
-class CreateUsers < ActiveRecord::Migration[7.0]
-  def change
-    create_table :users do |t|
-      t.string :email, null: false
-
-      t.index 'LOWER(email)', unique: true, name: 'index_users_on_lowercase_email'
-
-      t.timestamps
-    end
-  end
-end
-```
-
-
-Finally, mount the engine in your routes:
+Then mount the engine in your routes:
 
 ```ruby
 Rails.application.routes.draw do


### PR DESCRIPTION
In the README, we already give a code sample that creates User model and CreateUsers migration:

```shell
$ bin/rails generate model User email
```

And then we display the code for User model, showing how to mark the passwordless email field:

```ruby
class User < ApplicationRecord
  validates :email,
            presence: true,
            uniqueness: { case_sensitive: false },
            format: { with: URI::MailTo::EMAIL_REGEXP }

  passwordless_with :email # <-- here!
end
```

 Since this snippet already shows the example of how to validate an email field, I believe it's useful to also feature a snippet that adds similar db-level constraint. The idea is to ensure data integrity in case records are modified outside Rails (or within Rails when validations are skipped).

Here's how I do it:

```ruby
class CreateUsers < ActiveRecord::Migration[7.0]
  def change
    create_table :users do |t|
      t.string :email, null: false

      t.index 'LOWER(email)', unique: true, name: 'index_users_on_lowercase_email'

      t.timestamps
    end
  end
end
```

It is not exactly the same as the model validation - this doesn't validate email format. But personally, I don't care because this is only to ensure email uniqueness. If an invalid email is saved forcibly, the worst that's going to happen is that that one user won't be able to log in.