### PR TITLE
Use default from address of parent when default_from_address is nil

### DIFF
--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -3,7 +3,7 @@
 module Passwordless
   # The mailer responsible for sending Passwordless' mails.
   class Mailer < Passwordless.config.parent_mailer.constantize
-    default from: Passwordless.config.default_from_address
+    default(from: Passwordless.config.default_from_address) if Passwordless.config.default_from_address
 
     # Sends a token and a magic link
     #

--- a/test/mailers/passwordless/mailer_test.rb
+++ b/test/mailers/passwordless/mailer_test.rb
@@ -49,7 +49,7 @@ class Passwordless::MailerTest < ActionMailer::TestCase
       # parent class for the mailer. This means `Passwordless::Mailer` needs
       # to be reloaded, otherwise it will still have the old parent class.
       reload_mailer!
-      
+
       session = Passwordless::Session.create!(authenticatable: users(:alice), token: "hello")
       email = Passwordless::Mailer.sign_in(session, "hello")
 
@@ -58,6 +58,16 @@ class Passwordless::MailerTest < ActionMailer::TestCase
   ensure
     # Reload the mailer again, because the config is reset back to the default
     # after the `with_config` block.
+    reload_mailer!
+  end
+
+  test("uses default from address of parent when default_from_address is nil") do
+    with_config({parent_mailer: "ApplicationMailer", default_from_address: nil}) do
+      reload_mailer!
+
+      assert_equal ApplicationMailer.default.fetch(:from), Passwordless::Mailer.default.fetch(:from)
+    end
+  ensure
     reload_mailer!
   end
 end


### PR DESCRIPTION
I think it makes sense to use the default from address of the parent to avoid duplication. I think this isn't a breaking change because it made no sense to set the option `nil` before.