### PR TITLE
Add parent controller option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Enable Passwordless on your user model by pointing it to the email field:
 ```ruby
 class User < ApplicationRecord
   # your other code..
-  
+
   passwordless_with :email # <-- here! this needs to be a column in `users` table
-  
+
   # more of your code..
 end
 ```
@@ -158,6 +158,7 @@ The default values are shown below. It's recommended to only include the ones th
 ```ruby
 Passwordless.configure do |config|
   config.default_from_address = "CHANGE_ME@example.com"
+  config.parent_controller = "ApplicationController"
   config.parent_mailer = "ActionMailer::Base"
   config.restrict_token_reuse = false # Can a token/link be used multiple times?
   config.token_generator = Passwordless::ShortTokenGenerator.new # Used to generate magic link tokens.

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -4,7 +4,7 @@ require "bcrypt"
 
 module Passwordless
   # Controller for managing Passwordless sessions
-  class SessionsController < ApplicationController
+  class SessionsController < Passwordless.config.parent_controller.constantize
     include ControllerHelpers
 
     helper_method :email_field
@@ -51,7 +51,7 @@ module Passwordless
 
     rescue ActiveRecord::RecordNotFound
       @session = Session.new
-      
+
       flash[:error] = I18n.t("passwordless.sessions.create.not_found")
       render(:new, status: :not_found)
     end

--- a/lib/passwordless/config.rb
+++ b/lib/passwordless/config.rb
@@ -28,6 +28,7 @@ module Passwordless
     include Options
 
     option :default_from_address, default: "CHANGE_ME@example.com"
+    option :parent_controller, default: "ApplicationController"
     option :parent_mailer, default: "ActionMailer::Base"
     option :restrict_token_reuse, default: true
     option :token_generator, default: ShortTokenGenerator.new

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -207,6 +207,19 @@ module Passwordless
       end
     end
 
+    test("custom parent") do
+      class Passwordless::CustomParentController < ActionController::Base; end
+
+      with_config({parent_controller: "Passwordless::CustomParentController"}) do
+        reload_controller!
+
+        assert_equal Passwordless::CustomParentController, Passwordless::SessionsController.superclass
+      end
+    ensure
+      reload_controller!
+      Passwordless.send(:remove_const, :CustomParentController)
+    end
+
     class Helpers
       extend Passwordless::ControllerHelpers
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,12 +60,17 @@ module WithConfig
 
   # Reloads the Mailer by removing its constant and reloading the mailer file
   # manually. This is quite a hack, but it seems to work.
-  # 
+  #
   # This can be used when you change the`parent_mailer` config option and need
   # it load a different parent class.
   def reload_mailer!
     Passwordless.send(:remove_const, :Mailer)
     load File.expand_path("../../app/mailers/passwordless/mailer.rb", __FILE__)
+  end
+
+  def reload_controller!
+    Passwordless.send(:remove_const, :SessionsController)
+    load File.expand_path("../../app/controllers/passwordless/sessions_controller.rb", __FILE__)
   end
 end
 


### PR DESCRIPTION
I think this makes sense because it follows the same pattern as `parent_mailer`. It is possible to extract the base controller logic into a concern and include that in a custom Passwordless controller but using an option would be more convenient.