### PR TITLE
Evaluate callable redirects in context of controller

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -170,7 +170,7 @@ module Passwordless
 
     def call_or_return(value)
       if value.respond_to?(:call)
-        instance_eval(&value)
+        instance_exec(&value)
       else
         value
       end

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -169,7 +169,11 @@ module Passwordless
     end
 
     def call_or_return(value)
-      value.respond_to?(:call) ? value.call : value
+      if value.respond_to?(:call)
+        instance_eval(&value)
+      else
+        value
+      end
     end
 
     def find_authenticatable

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -145,20 +145,26 @@ module Passwordless
       assert_equal pwless_session(User), Session.last!.id
     end
 
-    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / callable success path") do
+    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / callable success path with no args") do
       passwordless_session = create_pwless_session(token: "hi")
 
       with_config(success_redirect_path: lambda { "/" }) do
         patch("/users/sign_in/#{passwordless_session.identifier}", params: {passwordless: {token: "hi"}})
       end
 
-      assert_equal 303, status
+      follow_redirect!
+      assert_equal "/", path
+    end
+
+    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / callable success path with 1 arg") do
+      passwordless_session = create_pwless_session(token: "hi")
+
+      with_config(success_redirect_path: lambda { |user| "/#{user.id}" }) do
+        patch("/users/sign_in/#{passwordless_session.identifier}", params: {passwordless: {token: "hi"}})
+      end
 
       follow_redirect!
-      assert_equal 200, status
-      assert_equal "/", path
-
-      assert_equal pwless_session(User), Session.last!.id
+      assert_equal "/#{passwordless_session.authenticatable.id}", path
     end
 
     test("PATCH /:passwordless_for/sign_in/:id -> ERROR") do


### PR DESCRIPTION
Getting a little fancy here, perhaps too much, but I wanted something like this to work:

```ruby
Passwordless.configure do |config|
  config.success_redirect_path = -> (user) do
    user.creator? ? creators_path : members_path
  end
end
```

Of course, I could've made a dedicated "landing action" that handled this instead. But, …