### PR TITLE
replace flash[:error] with flash.alert

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -36,14 +36,14 @@ module Passwordless
           flash: {notice: I18n.t("passwordless.sessions.create.email_sent")}
         )
       else
-        flash[:error] = I18n.t("passwordless.sessions.create.error")
+        flash.alert = I18n.t("passwordless.sessions.create.error")
         render(:new, status: :unprocessable_entity)
       end
 
     rescue ActiveRecord::RecordNotFound
       @session = Session.new
 
-      flash[:error] = I18n.t("passwordless.sessions.create.not_found")
+      flash.alert = I18n.t("passwordless.sessions.create.not_found")
       render(:new, status: :not_found)
     end
 
@@ -156,15 +156,15 @@ module Passwordless
           **redirect_to_options
         )
       else
-        flash[:error] = I18n.t("passwordless.sessions.errors.invalid_token")
+        flash.alert = I18n.t("passwordless.sessions.errors.invalid_token")
         render(status: :forbidden, action: "show")
       end
 
     rescue Errors::TokenAlreadyClaimedError
-      flash[:error] = I18n.t("passwordless.sessions.errors.token_claimed")
+      flash.alert = I18n.t("passwordless.sessions.errors.token_claimed")
       redirect_to(passwordless_failure_redirect_path, status: :see_other, **redirect_to_options)
     rescue Errors::SessionTimedOutError
-      flash[:error] = I18n.t("passwordless.sessions.errors.session_expired")
+      flash.alert = I18n.t("passwordless.sessions.errors.session_expired")
       redirect_to(passwordless_failure_redirect_path, status: :see_other, **redirect_to_options)
     end
 

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -114,7 +114,7 @@ module Passwordless
       assert_equal 0, ActionMailer::Base.deliveries.size
 
       assert_template "passwordless/sessions/new"
-      assert_match "We couldn't find a user with that email address", flash[:error]
+      assert_match "We couldn't find a user with that email address", flash.alert
     end
 
     test("POST /:passwordless_for/sign_in -> ERROR / other error") do
@@ -129,7 +129,7 @@ module Passwordless
       assert_equal 0, ActionMailer::Base.deliveries.size
 
       assert_template "passwordless/sessions/new"
-      assert_match "An error occured", flash[:error]
+      assert_match "An error occured", flash.alert
     end
 
     test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS") do
@@ -196,7 +196,7 @@ module Passwordless
       follow_redirect!
       assert_equal 200, status
       assert_equal "/", path
-      assert_match "This link has already been used, try requesting the link again", flash[:error]
+      assert_match "This link has already been used, try requesting the link again", flash.alert
 
       assert_nil pwless_session(User)
     end
@@ -215,7 +215,7 @@ module Passwordless
       follow_redirect!
       assert_equal 200, status
       assert_equal "/", path
-      assert_match "Your session has expired", flash[:error]
+      assert_match "Your session has expired", flash.alert
 
       assert_nil pwless_session(User)
     end


### PR DESCRIPTION
Since Rails does not include a `:error` flash type, I think we should use the `flash.alert` flash type that [Rails provides](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Flash.html).