### PR TITLE
Disable autosave of session.authenticatable

### DIFF
--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -9,7 +9,8 @@ module Passwordless
     belongs_to(
       :authenticatable,
       polymorphic: true,
-      inverse_of: :passwordless_sessions
+      inverse_of: :passwordless_sessions,
+      autosave: false
     )
 
     validates(


### PR DESCRIPTION
This prevents the authenticable model from being auto-created when `config.paranoid = true`.

Fixes #217.