### PR TITLE
Disable autosave of session.authenticatable (cont.)

### DIFF
--- a/app/models/passwordless/session.rb
+++ b/app/models/passwordless/session.rb
@@ -9,7 +9,8 @@ module Passwordless
     belongs_to(
       :authenticatable,
       polymorphic: true,
-      inverse_of: :passwordless_sessions
+      inverse_of: :passwordless_sessions,
+      autosave: false
     )
 
     validates(

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -101,6 +101,7 @@ module Passwordless
       assert_equal 302, status
 
       assert_equal 0, ActionMailer::Base.deliveries.size
+      assert_nil Session.last.authenticatable
 
       follow_redirect!
       assert_equal "/users/sign_in/#{Session.last!.identifier}", path


### PR DESCRIPTION
This prevents the authenticable model from being auto-created when
`config.paranoid = true`.

Fixes #217.
