### PR TITLE
Drop explicit I18n load path configuration

### DIFF
--- a/lib/passwordless/engine.rb
+++ b/lib/passwordless/engine.rb
@@ -11,9 +11,5 @@ module Passwordless
       ActionDispatch::Routing::Mapper.include RouterHelpers
       ActiveRecord::Base.extend ModelHelpers
     end
-
-    config.before_initialize do |app|
-      app.config.i18n.load_path += Dir[Engine.root.join("config", "locales", "*.yml")]
-    end
   end
 end


### PR DESCRIPTION
There is currently a problem with locales load order such that in production, passwordless locale files come after the application locale files in the I18n load path

This prevents the application from overriding any translations

Rails engines don't need to explicitly configure this at least since 5.1.4 (the current minimum requirement)
  - https://api.rubyonrails.org/v5.1.4/classes/Rails/Engine.html