### PR TITLE
pass token to email subject translation

### DIFF
--- a/app/mailers/passwordless/mailer.rb
+++ b/app/mailers/passwordless/mailer.rb
@@ -26,7 +26,7 @@ module Passwordless
 
       mail(
         to: session.authenticatable.send(email_field),
-        subject: I18n.t("passwordless.mailer.sign_in.subject")
+        subject: I18n.t("passwordless.mailer.sign_in.subject", token: @token)
       )
     end
   end


### PR DESCRIPTION
I think it is better to have the option to pass the token in the email subject, so we do not need to even open the email, maybe we can only see the notification in the phone and right there will be the token.

With this change we could use the token in the email subject locales key.

![CleanShot 2024-04-26 at 19 14 22@2x](https://github.com/mikker/passwordless/assets/6332263/6c714ca1-ff66-4646-847e-032abb4a4a6d)
