### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Passwordless.configure do |config|
   config.default_from_address = "CHANGE_ME@example.com"
   config.parent_controller = "ApplicationController"
   config.parent_mailer = "ActionMailer::Base"
-  config.restrict_token_reuse = false # Can a token/link be used multiple times?
+  config.restrict_token_reuse = true # Can a token/link be used multiple times?
   config.token_generator = Passwordless::ShortTokenGenerator.new # Used to generate magic link tokens.
 
   config.expires_at = lambda { 1.year.from_now } # How long until a signed in session expires.


### PR DESCRIPTION
Update the readme to indicate that `restrict_token_reuse` defaults to `true` rather than `false`.