### PR TITLE
Prompt to change belongs_to type for e.g. UUIDs

### DIFF
--- a/db/migrate/20171104221735_create_passwordless_sessions.rb
+++ b/db/migrate/20171104221735_create_passwordless_sessions.rb
@@ -6,6 +6,7 @@ class CreatePasswordlessSessions < ActiveRecord::Migration[6.0]
       t.belongs_to(
         :authenticatable,
         polymorphic: true,
+        type: :int, # change to e.g. :uuid if your model doesn't use integer IDs
         index: {name: "authenticatable"}
       )
 


### PR DESCRIPTION
Took me the longest time to figure out why I couldn't authenticate: I've set up my models to use UUIDs, and it takes a manual step to set up the migration to be compatible with this. This will prompt the next developer to avoid the two hours I lost figuring this out. (-: