### PR TITLE
Require email presence in SIGN_IN

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -189,10 +189,16 @@ module Passwordless
     end
 
     def find_authenticatable
-      if authenticatable_class.respond_to?(:fetch_resource_for_passwordless)
-        authenticatable_class.fetch_resource_for_passwordless(normalized_email_param)
+      email = normalized_email_param
+      
+      if email.match?(URI::MailTo::EMAIL_REGEXP)
+        if authenticatable_class.respond_to?(:fetch_resource_for_passwordless)
+          authenticatable_class.fetch_resource_for_passwordless(email)
+        else
+          authenticatable_class.where("lower(#{email_field}) = ?", email).first
+        end
       else
-        authenticatable_class.where("lower(#{email_field}) = ?", normalized_email_param).first
+        raise ArgumentError, "Invalid email format"
       end
     end
 

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -191,14 +191,16 @@ module Passwordless
     def find_authenticatable
       email = normalized_email_param
       
-      if email.match?(URI::MailTo::EMAIL_REGEXP)
+      if email.blank?
+        raise ArgumentError, I18n.t("passwordless.sessions.errors.email_cannot_be_blank")
+      elsif !email.match?(URI::MailTo::EMAIL_REGEXP)
+        raise ArgumentError, I18n.t("passwordless.sessions.errors.invalid_email_format")
+      else
         if authenticatable_class.respond_to?(:fetch_resource_for_passwordless)
           authenticatable_class.fetch_resource_for_passwordless(email)
         else
           authenticatable_class.where("lower(#{email_field}) = ?", email).first
         end
-      else
-        raise ArgumentError, "Invalid email format"
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,8 @@ en:
         invalid_token: "Token is invalid"
         session_expired: "Your session has expired, please sign in again."
         token_claimed: "This link has already been used, try requesting the link again"
+        email_cannot_be_blank: "Email address cannot be blank"
+        invalid_email_format: "Invalid email format"
       destroy:
         signed_out: "Signed out successfully"
     mailer:

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -56,11 +56,26 @@ module Passwordless
 
     test("POST /:passwordless_for/sign_in -> FAILURE / invalid email format") do
       post("/users/sign_in", params: {passwordless: {email: "invalid_email"}})
-
-      assert_equal 200, status  # Expecting to re-render the form
-      assert_equal 0, ActionMailer::Base.deliveries.size
       
+      assert_equal 200, status
+      assert_equal 0, ActionMailer::Base.deliveries.size
       assert_includes response.body, "Invalid email format"
+    end
+
+    test("POST /:passwordless_for/sign_in -> FAILURE / empty email") do
+      post("/users/sign_in", params: {passwordless: {email: ""}})
+      
+      assert_equal 200, status
+      assert_equal 0, ActionMailer::Base.deliveries.size
+      assert_includes response.body, "Email address cannot be blank"
+    end
+
+    test("POST /:passwordless_for/sign_in -> FAILURE / whitespace-only email") do
+      post("/users/sign_in", params: {passwordless: {email: "   "}})
+      
+      assert_equal 200, status
+      assert_equal 0, ActionMailer::Base.deliveries.size
+      assert_includes response.body, "Email address cannot be blank"
     end
 
     test("POST /:passwordless_for/sign_in -> SUCCESS / custom delivery method") do

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -54,6 +54,15 @@ module Passwordless
       assert_equal "/users/sign_in/#{Session.last!.identifier}", path
     end
 
+    test("POST /:passwordless_for/sign_in -> FAILURE / invalid email format") do
+      post("/users/sign_in", params: {passwordless: {email: "invalid_email"}})
+
+      assert_equal 200, status  # Expecting to re-render the form
+      assert_equal 0, ActionMailer::Base.deliveries.size
+      
+      assert_includes response.body, "Invalid email format"
+    end
+
     test("POST /:passwordless_for/sign_in -> SUCCESS / custom delivery method") do
       called = false
 


### PR DESCRIPTION
closes #129 

Our current implementation lacks robust server-side email validation, potentially allowing invalid or empty email addresses to be processed. This can lead to errors like `Net::SMTPSyntaxError` and a poor user experience.

## Solution
This PR introduces enhanced email validation in the `Passwordless::SessionsController`, specifically in the `find_authenticatable` method. It adds checks for:

1. Empty email addresses
2. Email format validation using `URI::MailTo::EMAIL_REGEXP`

## Changes
- Updated `find_authenticatable` method to explicitly check for blank emails and validate email format
- Added error handling in the `create` action to catch and display appropriate error messages
- Introduced new test cases to cover invalid email formats and empty email submissions

## Test Coverage
Added the following test cases:
- Submission of an invalid email format
- Submission of an empty email string
- Submission of a whitespace-only email string