### PR TITLE
Custom redirect locations

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -14,6 +14,9 @@ module Passwordless
     #   renders sessions/new.html.erb.
     def new
       @session = Session.new
+      unless params[:redirect_to].nil?
+        save_passwordless_redirect_location! authenticatable_class, params[:redirect_to]
+      end
     end
 
     # post '/:resource/sign_in'

--- a/lib/passwordless/controller_helpers.rb
+++ b/lib/passwordless/controller_helpers.rb
@@ -87,9 +87,11 @@ module Passwordless
     # Saves request.original_url as the redirect location for a
     # passwordless Model.
     # @param (see #authenticate_by_session)
+    # @param url [String] the url to redirect to
     # @return [String] the redirect url that was just saved.
-    def save_passwordless_redirect_location!(authenticatable_class)
-      session[redirect_session_key(authenticatable_class)] = request.original_url
+    def save_passwordless_redirect_location!(authenticatable_class, url=nil)
+      url = request.original_url if url.nil?
+      set_passwordless_redirect_location! url
     end
 
     # Resets the redirect_location to root_path by deleting the redirect_url


### PR DESCRIPTION
This PR extends the behavior of `save_passwordless_redirect_location!` to support saving custom URLs, and uses it to support implementing `redirect_to` parameter on the `#new` action. Example usage:

```ruby
<%= link_to "Sign up or sign in", users_sign_in_path(redirect_to: request.url) %>
```