### PR TITLE
Make route sign in/out path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Add authentication to your Rails app without all the icky-ness of passwords. _Ma
   - [Route constraints](#route-constraints)
 - [Configuration](#configuration)
   - [Delivery method](#delivery-method)
+- [After Session Confirm Hook](#after-session-confirm-hook)
   - [Token generation](#token-generation)
   - [Timeout and Expiry](#timeout-and-expiry)
   - [Redirection after sign-in](#redirection-after-sign-in)
@@ -241,6 +242,9 @@ Passwordless.configure do |config|
   config.success_redirect_path = '/' # After a user successfully signs in
   config.failure_redirect_path = '/' # After a sign in fails
   config.sign_out_redirect_path = '/' # After a user signs out
+
+  config.sign_in_path_name = "sign_in" # Path name for sign in routes (e.g., "login")
+  config.sign_out_path_name = "sign_out" # Path name for sign out routes (e.g., "logout")
 
   config.paranoid = false # Display email sent notice even when the resource is not found.
 

--- a/lib/passwordless/config.rb
+++ b/lib/passwordless/config.rb
@@ -57,6 +57,9 @@ module Passwordless
       end
     )
 
+    option :sign_in_path_name, default: "sign_in"
+    option :sign_out_path_name, default: "sign_out"
+
     def initialize
       set_defaults!
     end

--- a/lib/passwordless/router_helpers.rb
+++ b/lib/passwordless/router_helpers.rb
@@ -29,13 +29,16 @@ module Passwordless
 
       pwless_resource = Passwordless.add_resource(resource, controller: controller)
 
+      sign_in_path  = Passwordless.config.sign_in_path_name
+      sign_out_path = Passwordless.config.sign_out_path_name
+
       scope(defaults: pwless_resource.defaults) do
-        get("#{at}/sign_in", to: "#{controller}#new", as: :"#{as}sign_in")
-        post("#{at}/sign_in", to: "#{controller}#create")
-        get("#{at}/sign_in/:id", to: "#{controller}#show", as: :"verify_#{as}sign_in")
-        get("#{at}/sign_in/:id/:token", to: "#{controller}#confirm", as: :"confirm_#{as}sign_in")
-        patch("#{at}/sign_in/:id", to: "#{controller}#update")
-        match("#{at}/sign_out", to: "#{controller}#destroy", via: %i[get delete], as: :"#{as}sign_out")
+        get("#{at}/#{sign_in_path}", to: "#{controller}#new", as: :"#{as}#{sign_in_path}")
+        post("#{at}/#{sign_in_path}", to: "#{controller}#create")
+        get("#{at}/#{sign_in_path}/:id", to: "#{controller}#show", as: :"verify_#{as}#{sign_in_path}")
+        get("#{at}/#{sign_in_path}/:id/:token", to: "#{controller}#confirm", as: :"confirm_#{as}#{sign_in_path}")
+        patch("#{at}/#{sign_in_path}/:id", to: "#{controller}#update")
+        match("#{at}/#{sign_out_path}", to: "#{controller}#destroy", via: %i[get delete], as: :"#{as}#{sign_out_path}")
       end
     end
   end


### PR DESCRIPTION
This change makes it possible to rename the sign in/out routes that passwordless uses via configuration. Example:

```ruby
Passwordless.configure do |config|
  config.sign_in_path_name  = 'login'
  config.sign_out_path_name = 'logout'
end
```