### PR TITLE
readme: update default delivery behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ In `config/initializers/passwordless.rb`:
 Passwordless.configure do |config|
   config.after_session_save = lambda do |session, request|
     # Default behavior is
-    # Passwordless::Mailer.sign_in(session).deliver_now
+    # Passwordless::Mailer.sign_in(session, session.token).deliver_now
 
     # You can change behavior to do something with session model. For example,
     # SmsApi.send_sms(session.authenticatable.phone_number, session.token)


### PR DESCRIPTION
The Code in the README doesn't match the actual implementation https://github.com/mikker/passwordless/blob/d30862d49d37237d7b32cf6ccc42c1cef9befdb2/lib/passwordless/config.rb#L48.