### PR TITLE
Secure generation of token

### DIFF
--- a/lib/passwordless/short_token_generator.rb
+++ b/lib/passwordless/short_token_generator.rb
@@ -3,7 +3,7 @@ module Passwordless
     CHARS = [*"A".."Z", *"0".."9"].freeze
 
     def call(_session)
-      SecureRandom.alphanumeric(6, chars: CHARS)
+      CHARS.sample(6, random: SecureRandom).join
     end
   end
 end


### PR DESCRIPTION
Array#sample uses Ruby's pseudorandom number generator, which "is not for cryptographical use". The algorithm is deterministic and recoverable once enough output samples are known. 

Switch to generating the token via SecureRandom.alphanumeric to make it non-deterministic.