### PR TITLE
Ignore "session not found" if paranoid is switched on

### DIFF
--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -85,9 +85,13 @@ module Passwordless
 
       @session = passwordless_session
 
-      artificially_slow_down_brute_force_attacks(params[:token])
+      if @session.present?
+        artificially_slow_down_brute_force_attacks(params[:token])
 
-      authenticate_and_sign_in(@session, params[:token])
+        authenticate_and_sign_in(@session, params[:token])
+      else
+        redirect_to users_sign_in_path
+      end
     end
 
     # match '/:resource/sign_out', via: %i[get delete].
@@ -253,6 +257,8 @@ module Passwordless
         identifier: params[:id],
         authenticatable_type: authenticatable_type
       )
+    rescue ActiveRecord::RecordNotFound
+      raise ActiveRecord::RecordNotFound, "Couldn't find session with id #{params[:id]}" unless Passwordless.config.paranoid
     end
 
     def passwordless_session_params

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -30,6 +30,22 @@ module Passwordless
       assert_template "passwordless/sessions/show"
     end
 
+    test("GET /:passwordless_for/sign_in/:id -> ERROR / garbage sent through as id") do
+      assert_raises ActiveRecord::RecordNotFound do
+        get("/users/sign_in/wp-includes/wlwmanifest.xml")
+      end
+    end
+
+    test("GET /:passwordless_for/sign_in/:id -> SUCCESS / garbage sent through as id and paranoid enabled") do
+      with_config(paranoid: true) do
+        get("/users/sign_in/wp-includes/wlwmanifest.xml")
+      end
+
+      assert_equal 302, status
+      follow_redirect!
+      assert_equal "/users/sign_in", path
+    end
+
     test("POST /:passwordless_for/sign_in -> SUCCESS") do
       create_user(email: "a@a")
 


### PR DESCRIPTION
If a bot or script is hitting the user sign in, then the `id` param can be something unsuitable, i.e. not an id in the database. The app then throws an `ActiveRecord::NotFound` exception.

This change alters the behaviour so that if paranoid is switched on, then the app ignores the not found and redirects back to the signin page.

However, I would understand if 

a) This should be the default behaviour and ignore the paranoid config
b) Current behaviour is desired!

This is related to issue #241 


