### PR TITLE
[docs] Fix param order for after_session_confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Passwordless.configure do |config|
 
   config.paranoid = false # Display email sent notice even when the resource is not found.
 
-  config.after_session_confirm = ->(request, session) {} # Called after a session is confirmed.
+  config.after_session_confirm = ->(session, request) {} # Called after a session is confirmed.
 end
 ```
 


### PR DESCRIPTION
Hey @mikker hope you've been well. Just spotted that the example config options have the params reversed for `after_session_confirm`.