### PR TITLE
New.html.erb params.fetch always returns nil 

### DIFF
--- a/app/views/passwordless/sessions/new.html.erb
+++ b/app/views/passwordless/sessions/new.html.erb
@@ -4,7 +4,7 @@
       t("passwordless.sessions.new.email.label"),
       for: "passwordless_#{email_field}" %>
   <%= email_field_tag email_field_name,
-      params.fetch(email_field_name, nil),
+      params.dig(:passwordless, email_field),
       required: true,
       autofocus: true,
       placeholder: t("passwordless.sessions.new.email.placeholder") %>


### PR DESCRIPTION
Instead of using `params.fetch(email_field_name, nil)`, we should use `params.dig(:passwordless, email_field)`. 

If we use params.fetch(email_field_name), we try to look for something like this 
`params.fetch(:"passwordless[email]")`

But because rails converts params to a shape like this 
`passwordless: { email: "email@example.com" }`
`params.fetch(email_field_name, nil)` always returns nil. 