### PR TITLE
Use flash.now instead of flash where we render 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
             ruby: "3.0"
           - gemfile: gemfiles/Gemfile-rails-main
             ruby: "3.1"
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: "3.2"
           - gemfile: gemfiles/Gemfile-rails-6-1
             ruby: "3.4"
           - gemfile: gemfiles/Gemfile-rails-7-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
             ruby: "3.0"
           - gemfile: gemfiles/Gemfile-rails-main
             ruby: "3.1"
-          - gemfile: gemfiles/Gemfile-rails-main
-            ruby: "3.2"
           - gemfile: gemfiles/Gemfile-rails-6-1
             ruby: "3.4"
           - gemfile: gemfiles/Gemfile-rails-7-0

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -36,14 +36,14 @@ module Passwordless
           flash: {notice: I18n.t("passwordless.sessions.create.email_sent")}
         )
       else
-        flash.alert = I18n.t("passwordless.sessions.create.error")
+        flash.now.alert = I18n.t("passwordless.sessions.create.error")
         render(:new, status: :unprocessable_entity)
       end
 
     rescue ActiveRecord::RecordNotFound
       @session = Session.new
 
-      flash.alert = I18n.t("passwordless.sessions.create.not_found")
+      flash.now.alert = I18n.t("passwordless.sessions.create.not_found")
       render(:new, status: :not_found)
     end
 
@@ -157,7 +157,7 @@ module Passwordless
           **redirect_to_options
         )
       else
-        flash.alert = I18n.t("passwordless.sessions.errors.invalid_token")
+        flash.now.alert = I18n.t("passwordless.sessions.errors.invalid_token")
         render(status: :forbidden, action: "show")
       end
 

--- a/gemfiles/Gemfile-rails-6-1
+++ b/gemfiles/Gemfile-rails-6-1
@@ -12,7 +12,7 @@ gem "bigdecimal"
 group :test do
   gem "capybara", require: false
   gem "codecov", require: false
-  gem "minitest"
+  gem "minitest", "~> 5.0"
   gem "rails-controller-testing"
   gem "ostruct"
   gem "benchmark"

--- a/gemfiles/Gemfile-rails-7-0
+++ b/gemfiles/Gemfile-rails-7-0
@@ -12,7 +12,7 @@ gem "bigdecimal"
 group :test do
   gem "capybara", require: false
   gem "codecov", require: false
-  gem "minitest"
+  gem "minitest", "~> 5.0"
   gem "rails-controller-testing"
   gem "ostruct"
   gem "benchmark"

--- a/gemfiles/Gemfile-rails-7-1
+++ b/gemfiles/Gemfile-rails-7-1
@@ -10,7 +10,7 @@ gem "yard"
 group :test do
   gem "capybara", require: false
   gem "codecov", require: false
-  gem "minitest"
+  gem "minitest", "~> 5.0"
   gem "rails-controller-testing"
   gem "ostruct"
   gem "benchmark"

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -107,7 +107,7 @@ module Passwordless
       assert_equal "/users/sign_in/#{Session.last!.identifier}", path
     end
 
-    test("POST /:passwordless_for/sign_in -> ERROR / not found and paranoid disabled") do
+    test("POST /:passwordless_for/sign_in -> ERROR / not found and paranoid disabled does not persist alert") do
       post("/users/sign_in", params: {passwordless: {email: "A@a"}})
 
       assert_equal 404, status
@@ -116,9 +116,12 @@ module Passwordless
 
       assert_template "passwordless/sessions/new"
       assert_match "We couldn't find a user with that email address", flash.alert
+
+      get "/users/sign_in"
+      assert_no_match "We couldn't find a user with that email address", flash.alert
     end
 
-    test("POST /:passwordless_for/sign_in -> ERROR / other error") do
+    test("POST /:passwordless_for/sign_in -> ERROR / other error does not persist alert") do
       create_user(email: "a@a")
 
       with_config(expires_at: lambda { nil }) do
@@ -131,6 +134,9 @@ module Passwordless
 
       assert_template "passwordless/sessions/new"
       assert_match "An error occurred", flash.alert
+
+      get "/users/sign_in"
+      assert_no_match "An error occurred", flash.alert
     end
 
     test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS") do
@@ -224,16 +230,16 @@ module Passwordless
     test("PATCH /:passwordless_for/sign_in/:id -> after_session_confirm with request object") do
       user = create_user(email: "test@example.com")
       passwordless_session = create_pwless_session(authenticatable: user, token: "valid_token")
-      
+
       confirm_called = false
-      
-      with_config(after_session_confirm: ->(session, request) { 
+
+      with_config(after_session_confirm: ->(session, request) {
         confirm_called = true
         assert_equal user, session.authenticatable
         assert_kind_of ActionDispatch::Request, request
       }) do
         patch(
-          "/users/sign_in/#{passwordless_session.identifier}", 
+          "/users/sign_in/#{passwordless_session.identifier}",
           params: {passwordless: {token: "valid_token"}}
         )
       end
@@ -245,18 +251,35 @@ module Passwordless
     test("PATCH /:passwordless_for/sign_in/:id -> after_session_confirm not called on invalid token") do
       user = create_user(email: "test@example.com")
       passwordless_session = create_pwless_session(authenticatable: user, token: "valid_token")
-      
+
       confirm_called = false
-      
+
       with_config(after_session_confirm: ->(_) { confirm_called = true }) do
         patch(
-          "/users/sign_in/#{passwordless_session.identifier}", 
+          "/users/sign_in/#{passwordless_session.identifier}",
           params: {passwordless: {token: "invalid_token"}}
         )
       end
 
       assert_equal 403, status
       assert_not confirm_called, "after_session_confirm hook was called with invalid token"
+    end
+
+    test("PATCH /:passwordless_for/sign_in/:id -> ERROR / invalid token shows flash alert does not persist alert") do
+      user = create_user(email: "test@example.com")
+      passwordless_session = create_pwless_session(authenticatable: user, token: "valid_token")
+
+      patch(
+        "/users/sign_in/#{passwordless_session.identifier}",
+        params: {passwordless: {token: "invalid_token"}}
+      )
+
+      assert_equal 403, status
+      assert_template "passwordless/sessions/show"
+      assert_match "Token is invalid", flash.alert
+
+      get "/users/sign_in"
+      assert_no_match "Token is invalid", flash.alert
     end
 
     test("DELETE /:passwordless_for/sign_out") do


### PR DESCRIPTION
**Issue:** the alert from a failed login is appearing on other pages of our application (that can display flash alert/notice)

**Fix:** When we are calling render, we call `flash.now.alert =` instead of `flash.alert =`, and that will stop the error message from mistakenly appearing on other pages within the application. 

**Investigation Notes:**
According to here 
https://thoughtbot.com/blog/rails-flashes-guide#flash-vs-flashnow

(I also looked at here, but it's in Japanese. It has nicer screenshots tho. https://qiita.com/taraontara/items/2db82e6a0b528b06b949)

> When you set flash, the value is stored in session and persisted until the next request. This is useful for showing a message after a redirect.
> 
> When you set flash.now, the value is only persisted for the duration of the current request. This is useful for showing a message before rendering.

