### PR TITLE
Use "url_from" to validate destination_path to avoid potential open redirect attack 

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,21 @@ end
 
 This can also be turned off with `Passwordless.config.redirect_back_after_sign_in = false`.
 
+### Redirecting to external hosts (Multi-tenant applications)
+
+By default, `passwordless` strictly protects against Open Redirect vulnerabilities. When a user logs in, the `destination_path` parameter is sanitized using Rails' native `url_from` helper. This guarantees that users can only be redirected to safe, relative paths within your application.
+
+If you are building a multi-tenant application and legitimately need to redirect users to external subdomains or different hosts after authentication, you have two options depending on your Rails version:
+
+**For Rails 8.1+**
+Rails natively supports external redirect allowlisting. You can specify your trusted domains in your environment configuration, and `passwordless` will automatically respect them:
+
+# config/environments/production.rb
+config.action_controller.allowed_redirect_hosts = ["staging.yoursite.com", "app.yoursite.com"]
+
+**For Rails 8.0 and older**
+You will need to manually override the redirect behavior to bypass the default security checks. You can do this by overriding the `passwordless_query_redirect_path` helper in your `ApplicationController` and implementing your own strict domain allowlist before returning a full URL.
+
 ### Looking up the user
 
 By default Passwordless uses the `passwordless_with` column to _case insensitively_ fetch the user resource.

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Rails natively supports external redirect allowlisting. You can specify your tru
 config.action_controller.allowed_redirect_hosts = ["staging.yoursite.com", "app.yoursite.com"]
 
 **For Rails 8.0 and older**
-You will need to manually override the redirect behavior to bypass the default security checks. You can do this by overriding the `passwordless_query_redirect_path` helper in your `ApplicationController` and implementing your own strict domain allowlist before returning a full URL.
+You will need to manually override the redirect behavior to bypass the default security checks. You can do this by overriding the `passwordless_query_redirect_path` helper in the `session_controller.rb`
 
 ### Looking up the user
 

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -114,10 +114,7 @@ module Passwordless
     end
 
     def passwordless_query_redirect_path
-      query_redirect_uri = URI(params[:destination_path])
-      query_redirect_uri.to_s if query_redirect_uri.host.nil? || query_redirect_uri.host == URI(request.url).host
-    rescue URI::InvalidURIError, ArgumentError
-      nil
+      url_from(params[:destination_path])
     end
 
     def passwordless_success_redirect_path(authenticatable)

--- a/app/controllers/passwordless/sessions_controller.rb
+++ b/app/controllers/passwordless/sessions_controller.rb
@@ -114,7 +114,16 @@ module Passwordless
     end
 
     def passwordless_query_redirect_path
-      url_from(params[:destination_path])
+      destination_path = params[:destination_path].to_s
+
+      return url_from(destination_path) if respond_to?(:url_from)
+
+      uri = URI.parse(destination_path)
+      if (uri.host.nil? && destination_path.start_with?('/') && !destination_path.start_with?('//')) || uri.host == request.host
+        destination_path
+      end
+    rescue URI::InvalidURIError, ArgumentError
+      nil
     end
 
     def passwordless_success_redirect_path(authenticatable)

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -189,6 +189,56 @@ module Passwordless
       assert_equal pwless_session(User), Session.last!.id
     end
 
+    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / outside host destination_path falls back when not allowlisted") do
+      passwordless_session = create_pwless_session(token: "hi")
+
+      destination_path = "https://staging.yoursite.com/welcome"
+
+      patch(
+        "/users/sign_in/#{passwordless_session.identifier}",
+        params: {
+          passwordless: {token: "hi"},
+          destination_path: destination_path
+        }
+      )
+
+      assert_equal 303, status
+
+      follow_redirect!
+      assert_equal 200, status
+      assert_equal "/", path
+
+      assert_equal pwless_session(User), Session.last!.id
+    end
+
+    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / outside host destination_path redirects when allowlisted") do
+      unless ActionController::Base.respond_to?(:allowed_redirect_hosts)
+        skip("allowed_redirect_hosts is only available on Rails 8.1+")
+      end
+
+      passwordless_session = create_pwless_session(token: "hi")
+      destination_path = "https://staging.yoursite.com/welcome"
+
+      original_allowed_redirect_hosts = ActionController::Base.allowed_redirect_hosts
+      ActionController::Base.allowed_redirect_hosts = ["staging.yoursite.com"]
+
+      patch(
+        "/users/sign_in/#{passwordless_session.identifier}",
+        params: {
+          passwordless: {token: "hi"},
+          destination_path: destination_path
+        }
+      )
+
+      assert_equal 303, status
+      assert_equal destination_path, response.location
+      assert_equal pwless_session(User), Session.last!.id
+    ensure
+      if ActionController::Base.respond_to?(:allowed_redirect_hosts)
+        ActionController::Base.allowed_redirect_hosts = original_allowed_redirect_hosts
+      end
+    end
+
     test("PATCH /:passwordless_for/sign_in/:id -> ERROR") do
       passwordless_session = create_pwless_session(token: "hi")
 

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -169,6 +169,26 @@ module Passwordless
       assert_equal "/users/#{passwordless_session.authenticatable.id}", path
     end
 
+    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / unsafe destination_path falls back") do
+      passwordless_session = create_pwless_session(token: "hi")
+
+      patch(
+        "/users/sign_in/#{passwordless_session.identifier}",
+        params: {
+          passwordless: {token: "hi"},
+          destination_path: "-staging.com"
+        }
+      )
+
+      assert_equal 303, status
+
+      follow_redirect!
+      assert_equal 200, status
+      assert_equal "/", path
+
+      assert_equal pwless_session(User), Session.last!.id
+    end
+
     test("PATCH /:passwordless_for/sign_in/:id -> ERROR") do
       passwordless_session = create_pwless_session(token: "hi")
 
@@ -224,16 +244,16 @@ module Passwordless
     test("PATCH /:passwordless_for/sign_in/:id -> after_session_confirm with request object") do
       user = create_user(email: "test@example.com")
       passwordless_session = create_pwless_session(authenticatable: user, token: "valid_token")
-      
+
       confirm_called = false
-      
-      with_config(after_session_confirm: ->(session, request) { 
+
+      with_config(after_session_confirm: ->(session, request) {
         confirm_called = true
         assert_equal user, session.authenticatable
         assert_kind_of ActionDispatch::Request, request
       }) do
         patch(
-          "/users/sign_in/#{passwordless_session.identifier}", 
+          "/users/sign_in/#{passwordless_session.identifier}",
           params: {passwordless: {token: "valid_token"}}
         )
       end
@@ -245,12 +265,12 @@ module Passwordless
     test("PATCH /:passwordless_for/sign_in/:id -> after_session_confirm not called on invalid token") do
       user = create_user(email: "test@example.com")
       passwordless_session = create_pwless_session(authenticatable: user, token: "valid_token")
-      
+
       confirm_called = false
-      
+
       with_config(after_session_confirm: ->(_) { confirm_called = true }) do
         patch(
-          "/users/sign_in/#{passwordless_session.identifier}", 
+          "/users/sign_in/#{passwordless_session.identifier}",
           params: {passwordless: {token: "invalid_token"}}
         )
       end

--- a/test/controllers/passwordless/sessions_controller_test.rb
+++ b/test/controllers/passwordless/sessions_controller_test.rb
@@ -169,6 +169,23 @@ module Passwordless
       assert_equal "/users/#{passwordless_session.authenticatable.id}", path
     end
 
+    test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / safe destination_path") do
+      passwordless_session = create_pwless_session(token: "hi")
+      destination_path = "/staging"
+
+      patch(
+        "/users/sign_in/#{passwordless_session.identifier}",
+        params: {
+          passwordless: {token: "hi"},
+          destination_path: destination_path
+        }
+      )
+
+      assert_equal 303, status
+      assert_equal "#{request.base_url}#{destination_path}", response.location
+      assert_equal pwless_session(User), Session.last!.id
+    end
+
     test("PATCH /:passwordless_for/sign_in/:id -> SUCCESS / unsafe destination_path falls back") do
       passwordless_session = create_pwless_session(token: "hi")
 


### PR DESCRIPTION
Fixes [#270](https://github.com/mikker/passwordless/issues/270)

I updated the read me and added tests to confirm new behaviour. 

Users who are currently relying on both destination_path and allow_other_host will need to update their code. 